### PR TITLE
fix: deprecated c++17 no error & triton symref

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,10 @@ option(TRITON_BUILD_UT "Build C++ Triton Unit Tests" ON)
 option(TRITON_BUILD_WITH_CCACHE "Build with ccache (if available)" ON)
 set(TRITON_CODEGEN_BACKENDS "" CACHE STRING "Enable different codegen backends")
 
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
+endif()
+
 if(TRITON_BUILD_WITH_CCACHE)
   find_program(CCACHE_PROGRAM ccache)
   if(CCACHE_PROGRAM)

--- a/python/triton
+++ b/python/triton
@@ -1,1 +1,1 @@
-/root/share/Triton-distributed/3rdparty/triton/python/triton
+../3rdparty/triton/python/triton


### PR DESCRIPTION
Triton uses deprecated c++17 features and may crash compilation for newer libstdc++.so
To solve this, the PR only warns the deprecated declarations.