### PR TITLE
[Fix]: RMSNormConfig in megakernel without comments @dataclass

### DIFF
--- a/python/triton_dist/mega_triton_kernel/tasks/norm.py
+++ b/python/triton_dist/mega_triton_kernel/tasks/norm.py
@@ -43,7 +43,7 @@ class QKVPackQKNormRopeSplitVConfig(ConfigBase):
 class QKNormRopeUpdateKVCacheConfig(ConfigBase):
     pass
 
-
+@dataclass
 class RMSNormConfig(ConfigBase):
     BLOCK_SIZE_N: int = 2048
 


### PR DESCRIPTION
Class RMSNormConfig (ConfiguraBase) failed to run due to lack of annotation for dataclass.