### PR TITLE
fix 06-inter-node-reduce-scatter.py tutorial bug

### DIFF
--- a/tutorials/06-inter-node-reduce-scatter.py
+++ b/tutorials/06-inter-node-reduce-scatter.py
@@ -170,6 +170,7 @@ def create_reduce_scater_2d_ctx(
         max_M,
         N,
         rank,
+        local_rank,
         world_size,
         local_world_size,
         dtype,
@@ -198,7 +199,7 @@ def create_reduce_scater_2d_ctx(
     signal_bufs = nvshmem_create_tensors([world_size * num_signal_bufs],
                                          NVSHMEM_SIGNAL_DTYPE, rank,
                                          local_world_size)
-    signal_buf = signal_bufs[rank]
+    signal_buf = signal_bufs[local_rank]
     signal_buf.zero_()
 
     nvshmem_barrier_all_on_stream(torch.cuda.current_stream())
@@ -459,6 +460,7 @@ if __name__ == "__main__":
     rs_ctx = create_reduce_scater_2d_ctx(M,
                                          N,
                                          RANK,
+                                         LOCAL_RANK,
                                          WORLD_SIZE,
                                          LOCAL_WORLD_SIZE,
                                          output_dtype,


### PR DESCRIPTION
Hello!

In the `create_reduce_scater_2d_ctx` method of [06-inter-node-reduce-scatter.py](https://github.com/ByteDance-Seed/Triton-distributed/blob/main/tutorials/06-inter-node-reduce-scatter.py) tutorial. the global process rank was used to index the signal_bufs list during the initialization of signal_buf.

This resulted in an `IndexError` on any node other than the first (i.e., when rank >= local_world_size).

What is the solution?
The indexing for the signal_bufs list has been corrected to use local_rank instead of the global rank:
```Diff
- signal_buf = signal_bufs[rank]
+ signal_buf = signal_bufs[local_rank]
```

This change ensures that each process on a node correctly accesses its dedicated signal buffer from the list of local buffers. It resolves the crash and enables the proper initialization of the communication context for multi-node environments.

NOTE:
[from nvshmem_create_tensors:](https://github.com/ByteDance-Seed/Triton-distributed/blob/ff4b0d59be46f03ccc01f249206c9f372fcd9d4d/python/triton_dist/utils.py#L121)
 ```
rank_on_same_node_start = rank - local_rank
rank_on_same_node_end = rank_on_same_node_start + local_world_size
```

so then
len(signal_bufs) = rank_on_same_node_end - rank_on_same_node_start = (rank_on_same_node_start + local_world_size) - rank_on_same_node_start = local_world_size