### PR TITLE
Fix a bug in reduce_topk_kernel

### DIFF
--- a/python/triton_dist/kernels/nvidia/moe_reduce_rs.py
+++ b/python/triton_dist/kernels/nvidia/moe_reduce_rs.py
@@ -443,7 +443,7 @@ def reduce_topk_reduce_scatter_a2a_intra_node_kernel(
             out_ptr = tl.multiple_of(out_ptr, 16)
             reduce_topk_kernel(
                 input_this_chunk_ptr + peer * ntokens_per_rank * TOPK * stride_m,
-                expert_weight_ptr,
+                expert_weight_ptr + peer * ntokens_per_rank * TOPK if expert_weight_ptr is not None else None,
                 0,  # no scale
                 out_ptr + rank * ntokens_per_rank * stride_m,
                 ntokens_per_rank,

--- a/python/triton_dist/kernels/nvidia/moe_utils.py
+++ b/python/triton_dist/kernels/nvidia/moe_utils.py
@@ -316,11 +316,11 @@ def reduce_topk_kernel(
 
         if scale_ptr:  # rely on the compiler to move scale_ptr out of for-loop
             reduced_topk = tl.load(inptrs, mask=mask)
-            weight = tl.load(scale_ptr + offs_m, mask=mask_m)[:, None]
+            weight = tl.load(scale_ptr + offs_m * TOPK, mask=mask_m)[:, None]
             reduced_topk = reduced_topk * weight
             for i in range(1, TOPK):
                 val = tl.load(inptrs + i * stride_m, mask=mask)
-                weight = tl.load(scale_ptr + offs_m + i, mask=mask_m)[:, None]
+                weight = tl.load(scale_ptr + offs_m * TOPK + i, mask=mask_m)[:, None]
                 reduced_topk += val * weight
         else:
             reduced_topk = tl.load(inptrs, mask=mask)


### PR DESCRIPTION
Hello!

In the original implementation of `python/triton_dist/kernels/nvidia/moe_reduce_rs.py`, the multiplication with `expert_weight` is performed inside `moe_gather_rs_grouped_gemm_kernel`:

```
if A_scale_ptr:
    accumulator = accumulator * tl.load(A_scale_ptr + offs_gather_a[:, None], mask=token_mask[:, None])
```

However, when I tried moving the multiplication from `moe_gather_rs_grouped_gemm_kernel` to `reduce_topk_kernel`, I observed numerical differences between the outputs of `dist-triton` and PyTorch.

After investigation, I found that the issue was caused by an incorrect addressing of `scale_ptr` in `reduce_topk_kernel`. Specifically, the offset `offs_m` was not multiplied by `TOPK`.

This patch fixes the addressing bug, and the results are now numerically verified to match the PyTorch reference.