### PR TITLE
[AMD] Fix rocSHMEM segfault by explicitly cleaning up resources …

### DIFF
--- a/python/triton_dist/test/amd/test_gemm_rs_intra_node.py
+++ b/python/triton_dist/test/amd/test_gemm_rs_intra_node.py
@@ -280,5 +280,14 @@ if __name__ == "__main__":
     dist_print(f"dist-triton #{RANK}", dist_triton_perf, need_sync=True, allowed_ranks=list(range(WORLD_SIZE)))
     dist_print(f"torch #{RANK}", torch_perf, need_sync=True, allowed_ranks=list(range(WORLD_SIZE)))
 
+    # Explicitly delete rocSHMEM-backed tensors before finalization
+    # Without explicit cleanup, rocshmem barrier_all collective operation
+    # is called during python shutdown when some ranks may already have exited
+    del dist_gemm_rs_op
+    del input, weight, bias
+    del torch_output, dist_triton_output
+    torch.cuda.synchronize()
+    torch.distributed.barrier()
+
     pyrocshmem.rocshmem_finalize()
     torch.distributed.destroy_process_group()


### PR DESCRIPTION
Tests were seeing Segmentation fault during Python shutdown because barrier_all() was called when some ranks had already exited during rocshmem_finalize() operation.

- Add explicit deletion of rocSHMEM contexts and tensors before rocshmem_finalize()
- Prevents barrier_all() from being called during Python shutdown when ranks may have exited