### PR TITLE
UUID fix

### DIFF
--- a/python/triton_dist/amd_utils.py
+++ b/python/triton_dist/amd_utils.py
@@ -208,19 +208,23 @@ def _get_gpu_uuid_by_physical_device_id(device_id: int):
     _ensure_amdsmi_initialized()
     devices = amdsmi.amdsmi_get_processor_handles()
     handle = devices[device_id]
-    # Due to a change in how UUIDs are generated for CPX mode, amdsmi no longer reports any uuid value that
-    # matches HIP/pytorch. HIP gets the value from sysfs, and we can also get the value there by getting
-    # the KFD info from amdsmi and then probing the sysfs directly.
-    kfd_info = amdsmi.amdsmi_get_gpu_kfd_info(handle)
-    node_id = kfd_info["node_id"]
-    kfd_path = os.path.join("/sys/devices/virtual/kfd/kfd/topology/nodes", str(node_id), "properties")
-    key = "unique_id"
-    with open(kfd_path, "r") as fd:
-        for line in fd:
-            if line.startswith(key):
-                uuid_str = line[len(key)+1:]
-    uuid_str = hex(int(uuid_str))
-    return uuid_str
+    major_version = int(torch.version.hip.split('.')[0])
+    if major_version >= 7:
+        # Due to a change in how UUIDs are generated for CPX mode, amdsmi no longer reports any uuid value that
+        # matches HIP/pytorch. HIP gets the value from sysfs, and we can also get the value there by getting
+        # the KFD info from amdsmi and then probing the sysfs directly.
+        kfd_info = amdsmi.amdsmi_get_gpu_kfd_info(handle)
+        node_id = kfd_info["node_id"]
+        kfd_path = os.path.join("/sys/devices/virtual/kfd/kfd/topology/nodes", str(node_id), "properties")
+        key = "unique_id"
+        with open(kfd_path, "r") as fd:
+            for line in fd:
+                if line.startswith(key):
+                    uuid_str = line[len(key)+1:]
+        uuid_str = hex(int(uuid_str))
+        return uuid_str
+    else:
+        return amdsmi.amdsmi_get_gpu_device_uuid(handle)
 
 
 def torch_uuid_to_unique_id(torch_uuid: str) -> str:

--- a/tutorials/03a-inter-node-allgather.py
+++ b/tutorials/03a-inter-node-allgather.py
@@ -45,7 +45,7 @@ import pyrocshmem
 from triton_dist.language.extra.language_extra import __syncthreads, tid
 from triton_dist.language.extra import libshmem_device
 from triton_dist.profiler_utils import perf_func
-from triton_dist.utils import finalize_distributed, initialize_distributed, rocshmem_barrier_all_on_stream, NVSHMEM_SIGNAL_DTYPE
+from triton_dist.utils import finalize_distributed, initialize_distributed, rocshmem_barrier_all_on_stream, NVSHMEM_SIGNAL_DTYPE, sleep_async
 
 
 @dataclass
@@ -139,7 +139,7 @@ def perf_ag(func, ag_buffers: torch.Tensor, nbytes: int,
     print(f"✅ RANK[{RANK}] check passed")
 
     # perf all-gather by NCCL
-    #sleep_async(1000)  # in case CPU bound # Broken in rocm 7+
+    sleep_async(1000)  # in case CPU bound # Broken in rocm 7+
     _, duration_per_iter_ms = perf_func(
         _run_all_gather_nccl,
         warmup_iters=5,
@@ -153,7 +153,7 @@ def perf_ag(func, ag_buffers: torch.Tensor, nbytes: int,
 
     # perf all-gather by triton-distributed
     rocshmem_barrier_all_on_stream(torch.cuda.current_stream())
-    #sleep_async(1000)  # in case CPU bound
+    sleep_async(1000)  # in case CPU bound
     _, duration_per_iter_ms = perf_func(
         _run_all_gather_triton,
         warmup_iters=5,


### PR DESCRIPTION
In newer versions of ROCm, the sleep_async helper function fails because of a change in the way UUIDs work. This patch fixes the problem by pulling the UUID from KFD.