### PR TITLE
feat: Add ascend backend

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,9 @@
 [submodule "3rdparty/cutlass"]
 	path = 3rdparty/cutlass
 	url = https://github.com/NVIDIA/cutlass.git
+[submodule "3rdparty/shmem"]
+	path = 3rdparty/shmem
+	url = https://gitcode.com/cann/shmem.git
+[submodule "3rdparty/triton-ascend"]
+	path = 3rdparty/triton-ascend
+	url = https://gitcode.com/Ascend/triton-ascend.git

--- a/3rdparty/AscendNPU-IR.patch
+++ b/3rdparty/AscendNPU-IR.patch
@@ -1,0 +1,13 @@
+diff --git a/bishengir/include/bishengir/Dialect/HIVM/IR/HIVMOps.td b/bishengir/include/bishengir/Dialect/HIVM/IR/HIVMOps.td
+index 1d99d36..d66089f 100644
+--- a/bishengir/include/bishengir/Dialect/HIVM/IR/HIVMOps.td
++++ b/bishengir/include/bishengir/Dialect/HIVM/IR/HIVMOps.td
+@@ -504,7 +504,7 @@ def CustomOp
+   }];
+ 
+   let arguments = (ins StrAttr:$name, Variadic<AnyType>:$inputs,
+-      Variadic<AnyType>:$outputs, Variadic<AnyType>:$temp_buffers);
++      Variadic<AnyType>:$outputs, Variadic<AnyType>:$temp_buffers, UnitAttr:$no_side_effect);
+ 
+   let results = (outs Variadic<AnyType>:$results);
+ 

--- a/3rdparty/triton-ascend.patch
+++ b/3rdparty/triton-ascend.patch
@@ -1,0 +1,92 @@
+diff --git a/python/triton/compiler/code_generator.py b/python/triton/compiler/code_generator.py
+index 81b2d0a..1df8db3 100644
+--- a/python/triton/compiler/code_generator.py
++++ b/python/triton/compiler/code_generator.py
+@@ -18,7 +18,7 @@ from triton.extension.buffer.language import core as bl
+ from triton.extension.buffer.language.builder import setup_unified_builder_with_buffer_builder
+
+ from .. import knobs, language
+-from .._C.libtriton import ir, gluon_ir, buffer_ir
++from .._C.libtriton import ir, gluon_ir, buffer_ir, distributed
+ from .._C.libtriton.ascend import ir as ascend_ir
+ from ..language import constexpr, str_to_ty, tensor, tuple as tl_tuple
+ from ..language.core import _unwrap_if_constexpr, base_value, base_type
+@@ -324,6 +324,7 @@ class CodeGenerator(ast.NodeVisitor):
+                 self.builder = ir.builder(context, compile_mode="simt")
+             else:
+                 self.builder = ir.builder(context, compile_mode="simd")
++            self.builder = distributed.ir.DistributedOpBuilder(context)
+             self.semantic = TritonSemantic(self.builder)
+
+         self.name_loc_as_prefix = None
+diff --git a/python/triton/compiler/compiler.py b/python/triton/compiler/compiler.py
+index 08059cc..b17b7ff 100644
+--- a/python/triton/compiler/compiler.py
++++ b/python/triton/compiler/compiler.py
+@@ -1,7 +1,7 @@
+ from __future__ import annotations
+ import hashlib
+ import json
+-from .._C.libtriton import get_cache_invalidating_env_vars, ir, buffer_ir
++from .._C.libtriton import get_cache_invalidating_env_vars, ir, buffer_ir, distributed
+ from .._C.libtriton.ascend import ir as ascend_ir
+ from ..backends import backends
+ from ..backends.compiler import Language
+@@ -294,6 +294,7 @@ def compile(src, target=None, options=None, _env_vars=None):
+     if not isinstance(src, IRSource):
+         context = ir.context()
+         ir.load_dialects(context)
++        distributed.ir.load_dialects(context)
+         buffer_ir.load_dialects(context)
+         ascend_ir.load_dialects(context)
+         backend.load_dialects(context)
+diff --git a/third_party/ascend/backend/compiler.py b/third_party/ascend/backend/compiler.py
+index 7c78d6c..a61e8bb 100644
+--- a/third_party/ascend/backend/compiler.py
++++ b/third_party/ascend/backend/compiler.py
+@@ -31,7 +31,7 @@ from pathlib import Path
+ from types import ModuleType
+ from typing import Any, Dict, Optional, Tuple, Union
+
+-from triton._C.libtriton import ir, passes, ascend
++from triton._C.libtriton import ir, passes, ascend, distributed
+ from triton.backends.ascend.utils import (
+     _check_bishengir_api_change,
+     _check_bishengir_able_save_ir,
+@@ -116,6 +116,7 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
+             auto_blockify_size = 1
+         pm = ir.pass_manager(mod.context)
+         pm.enable_debug()
++        distributed.ascend_passes.ttgpuir.add_convert_triton_distributed_to_hivm(pm)
+         ascend.passes.ttir.add_auto_blockify(
+             pm,
+             auto_blockify_size
+diff --git a/third_party/ascend/backend/driver.py b/third_party/ascend/backend/driver.py
+index 1d5fc45..8c008f6 100644
+--- a/third_party/ascend/backend/driver.py
++++ b/third_party/ascend/backend/driver.py
+@@ -597,13 +597,7 @@ static inline DevicePtrInfo getPointer(PyObject *obj, int idx) {
+     aclError status = aclrtPointerGetAttributes(ptr_info.dev_ptr, &attributes);
+
+     if (status == ACL_SUCCESS) {
+-      if (attributes.location.type != ACL_MEM_LOCATION_TYPE_DEVICE && attributes.location.type != 4) {
+-        Py_DECREF(ret);
+-        PyErr_Format(PyExc_ValueError,
+-                     "Pointer argument (at %d) cannot be accessed from Triton (cpu tensor?)", idx);
+-        ptr_info.valid = false;
+-        return ptr_info;
+-      }
++
+     } else {
+       Py_DECREF(ret);
+       PyErr_Format(PyExc_RuntimeError,
+diff --git a/third_party/proton/Dialect/lib/ProtonGPUToLLVM/ProtonAMDGPUToLLVM/CMakeLists.txt b/third_party/proton/Dialect/lib/ProtonGPUToLLVM/ProtonAMDGPUToLLVM/CMakeLists.txt
+index 80b387a..6242c5f 100644
+--- a/third_party/proton/Dialect/lib/ProtonGPUToLLVM/ProtonAMDGPUToLLVM/CMakeLists.txt
++++ b/third_party/proton/Dialect/lib/ProtonGPUToLLVM/ProtonAMDGPUToLLVM/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-include_directories(${PROJECT_SOURCE_DIR}/third_party/amd/include)
++include_directories(${PROJECT_SOURCE_DIR}/3rdparty/triton-ascend/third_party/amd/include)
+
+ add_triton_library(ProtonAMDGPUToLLVM
+     TargetInfo.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,17 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 project(triton CXX C)
 include(CTest)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/triton/cmake")
+option(TRITON_USE_ASCEND "Build the Triton Ascend" OFF)
+
+if(TRITON_USE_ASCEND)
+  add_compile_definitions(TRITON_USE_ASCEND=1)
+endif()
+
+if(TRITON_USE_ASCEND)
+  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/triton-ascend/cmake")
+else()
+  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/triton/cmake")
+endif()
 
 # Options
 option(TRITON_BUILD_PYTHON_MODULE "Build Python Triton bindings" OFF)
@@ -85,7 +95,11 @@ if(TRITON_BUILD_UT)
 endif()
 
 # Compiler flags
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/triton/include)
+if(TRITON_USE_ASCEND)
+  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/triton-ascend/include)
+else()
+  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/triton/include)
+endif()
 if(NOT MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__STDC_FORMAT_MACROS  -fPIC -std=gnu++17")
 else()
@@ -101,6 +115,12 @@ endif()
 # #########
 if(NOT MLIR_DIR)
   set(MLIR_DIR ${LLVM_LIBRARY_DIR}/cmake/mlir)
+endif()
+
+if(TRITON_USE_ASCEND)
+  if(NOT LLD_DIR)
+    set(LLD_DIR ${LLVM_LIBRARY_DIR}/cmake/lld)
+  endif()
 endif()
 
 # MLIR
@@ -155,23 +175,57 @@ endif()
 
 include_directories(${PROJECT_SOURCE_DIR}/include)
 include_directories(${PROJECT_BINARY_DIR}/include)
-include_directories(${PROJECT_SOURCE_DIR}/3rdparty/triton)
+if(TRITON_USE_ASCEND)
+  include_directories(${PROJECT_SOURCE_DIR}/3rdparty/triton-ascend)
+else()
+  include_directories(${PROJECT_SOURCE_DIR}/3rdparty/triton)
+endif()
 include_directories(${MLIR_INCLUDE_DIRS})
 include_directories(${LLVM_INCLUDE_DIRS})
-include_directories(${PROJECT_SOURCE_DIR}/3rdparty/triton/include)
-include_directories(${PROJECT_BINARY_DIR}/3rdparty/triton/include) # Tablegen'd files
-include_directories(${PROJECT_SOURCE_DIR}/3rdparty/triton/third_party)
-include_directories(${PROJECT_BINARY_DIR}/3rdparty/triton/third_party) # Tablegen'd files
-# backend
-include_directories(${PROJECT_SOURCE_DIR}/3rdparty/triton/third_party/amd/include)
-include_directories(${PROJECT_SOURCE_DIR}/3rdparty/triton/third_party/nvidia/include)
+if(TRITON_USE_ASCEND)
+  include_directories(${PROJECT_SOURCE_DIR}/3rdparty/triton-ascend/include)
+  include_directories(${PROJECT_BINARY_DIR}/3rdparty/triton-ascend/include) # Tablegen'd files
+  include_directories(${PROJECT_SOURCE_DIR}/3rdparty/triton-ascend/third_party)
+  include_directories(${PROJECT_BINARY_DIR}/3rdparty/triton-ascend/third_party) # Tablegen'd files
+  include_directories(${PROJECT_SOURCE_DIR}/3rdparty/triton-ascend/third_party/ascend/AscendNPU-IR/bishengir/include)
+  include_directories(${PROJECT_BINARY_DIR}/3rdparty/triton-ascend/third_party/ascend/AscendNPU-IR/bishengir/include) # Tablegen'd files
+else()
+  include_directories(${PROJECT_SOURCE_DIR}/3rdparty/triton/include)
+  include_directories(${PROJECT_BINARY_DIR}/3rdparty/triton/include) # Tablegen'd files
+  include_directories(${PROJECT_SOURCE_DIR}/3rdparty/triton/third_party)
+  include_directories(${PROJECT_BINARY_DIR}/3rdparty/triton/third_party) # Tablegen'd files
+  # backend
+  include_directories(${PROJECT_SOURCE_DIR}/3rdparty/triton/third_party/amd/include)
+  include_directories(${PROJECT_SOURCE_DIR}/3rdparty/triton/third_party/nvidia/include)
+endif()
 if(TRITON_USE_MACA)
   include_directories(${PROJECT_SOURCE_DIR}/3rdparty/triton/third_party/metax/include)
 endif()
 
+# Adapter LLVM VERSION For AscendNPU IR
+option(LLVM_MAJOR_VERSION_21_COMPATIBLE "NPUIR build with LLVM 21 or later" OFF)
+if(LLVM_MAJOR_VERSION_21_COMPATIBLE)
+  message(STATUS "[TA]Building AscendNPU IR with LLVM 21 or later")
+  add_definitions(-D__LLVM_MAJOR_VERSION_21_COMPATIBLE__)
+endif()
+
+# Some compatibility changes for LLVM 21 are also needed on LLVM 22.
+# Therefore __LLVM_MAJOR_VERSION_21_COMPATIBLE__ would be enabled too.
+option(LLVM_MAJOR_VERSION_22_COMPATIBLE "NPUIR build with LLVM 22" OFF)
+if(LLVM_MAJOR_VERSION_22_COMPATIBLE)
+  message(STATUS "[TA]Building AscendNPU IR with LLVM 22 or later")
+  add_definitions(-D__LLVM_MAJOR_VERSION_21_COMPATIBLE__)
+  add_definitions(-D__LLVM_MAJOR_VERSION_22_COMPATIBLE__)
+endif()
+
 # link_directories(${LLVM_LIBRARY_DIR})
-add_subdirectory(3rdparty/triton/include)
-add_subdirectory(3rdparty/triton/lib)
+if(TRITON_USE_ASCEND)
+  add_subdirectory(3rdparty/triton-ascend/include)
+  add_subdirectory(3rdparty/triton-ascend/lib)
+else()
+  add_subdirectory(3rdparty/triton/include)
+  add_subdirectory(3rdparty/triton/lib)
+endif()
 add_subdirectory(include)
 add_subdirectory(lib)
 
@@ -190,10 +244,16 @@ endif()
 if(TRITON_BUILD_PYTHON_MODULE)
   message(STATUS "Adding Python module for TritonDistributed")
   set(PYTHON_DIST_SRC_PATH ${CMAKE_CURRENT_SOURCE_DIR}/python/src)
-  add_triton_plugin(TritonDistributed ${PYTHON_DIST_SRC_PATH}/triton_distributed.cc
-                                      ${PYTHON_DIST_SRC_PATH}/passes.cc
-                                      ${PYTHON_DIST_SRC_PATH}/ir.cc)
-  if(TRITON_USE_MACA)
+  if(TRITON_USE_ASCEND)
+    add_triton_plugin(TritonDistributed ${PYTHON_DIST_SRC_PATH}/triton_distributed.cc
+                                        ${PYTHON_DIST_SRC_PATH}/ascend_passes.cc
+                                        ${PYTHON_DIST_SRC_PATH}/ir.cc)
+  else()
+    add_triton_plugin(TritonDistributed ${PYTHON_DIST_SRC_PATH}/triton_distributed.cc
+                                        ${PYTHON_DIST_SRC_PATH}/passes.cc
+                                        ${PYTHON_DIST_SRC_PATH}/ir.cc)
+  endif()
+  if(TRITON_USE_MACA OR TRITON_USE_ASCEND)
     target_link_libraries(TritonDistributed PRIVATE DistributedIR Python3::Module pybind11::headers)
   else()
     target_link_libraries(TritonDistributed PRIVATE DistributedIR SIMTIR ProtonIR Python3::Module pybind11::headers)
@@ -202,12 +262,20 @@ endif()
 
 if(TRITON_BUILD_PYTHON_MODULE)
   message(STATUS "Adding Python module")
-  set(PYTHON_SRC_PATH ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/triton/python/src)
+  if(TRITON_USE_ASCEND)
+    set(PYTHON_SRC_PATH ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/triton-ascend/python/src)
+  else()
+    set(PYTHON_SRC_PATH ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/triton/python/src)
+  endif()
   include_directories(${PYTHON_SRC_PATH})
 
   # Python Interpreter is used to run lit tests
   find_package(Python3 REQUIRED COMPONENTS Development.Module Interpreter)
   find_package(pybind11 CONFIG REQUIRED HINTS "${Python3_SITELIB}")
+  if(TRITON_USE_ASCEND)
+    include_directories(${Python3_INCLUDE_DIR})
+    include_directories(${pybind11_INCLUDE_DIR})
+  endif()
 
   if (DEFINED TRITON_PLUGIN_DIRS)
     foreach(PLUGIN_DIR ${TRITON_PLUGIN_DIRS})
@@ -227,19 +295,34 @@ if(TRITON_BUILD_PYTHON_MODULE)
   endif()
 
   foreach(CODEGEN_BACKEND ${TRITON_CODEGEN_BACKENDS})
-    add_subdirectory(3rdparty/triton/third_party/${CODEGEN_BACKEND})
+    if(TRITON_USE_ASCEND)
+      add_subdirectory(3rdparty/triton-ascend/third_party/${CODEGEN_BACKEND})
+    else()
+      add_subdirectory(3rdparty/triton/third_party/${CODEGEN_BACKEND})
+    endif()
   endforeach()
 
   if (TRITON_BUILD_PROTON)
-    add_subdirectory(3rdparty/triton/third_party/proton)
+    if(TRITON_USE_ASCEND)
+      add_subdirectory(3rdparty/triton-ascend/third_party/proton)
+    else()
+      add_subdirectory(3rdparty/triton/third_party/proton)
+    endif()
+  endif()
+  if(TRITON_USE_ASCEND)
+    # We always build proton dialect
+    list(APPEND TRITON_PLUGIN_NAMES "proton")
+    add_subdirectory(3rdparty/triton-ascend/third_party/proton/Dialect)
   endif()
   if (TRITON_BUILD_DISTRIBUTED)
     add_subdirectory(csrc)
   endif()
   # build proton dialect
   if(NOT TRITON_USE_MACA)
-    list(APPEND TRITON_PLUGIN_NAMES "proton")
-    add_subdirectory(3rdparty/triton/third_party/proton/dialect)
+    if(NOT TRITON_USE_ASCEND)
+      list(APPEND TRITON_PLUGIN_NAMES "proton")
+      add_subdirectory(3rdparty/triton/third_party/proton/dialect)
+    endif()
   endif()
   # We always build distributed dialect
   list(APPEND TRITON_PLUGIN_NAMES "distributed")
@@ -330,6 +413,14 @@ if(TRITON_BUILD_PYTHON_MODULE)
                     ${PYTHON_SRC_PATH}/passes.cc
                     ${PYTHON_SRC_PATH}/interpreter.cc
                     ${PYTHON_SRC_PATH}/llvm.cc)
+  elseif(TRITON_USE_ASCEND)
+    add_library(triton SHARED ${PYTHON_SRC_PATH}/main.cc
+                ${PYTHON_SRC_PATH}/ir.cc
+                ${PYTHON_SRC_PATH}/../triton/extension/buffer/src/buffer_ir.cc
+                ${PYTHON_SRC_PATH}/gluon_ir.cc
+                ${PYTHON_SRC_PATH}/passes.cc
+                ${PYTHON_SRC_PATH}/interpreter.cc
+                ${PYTHON_SRC_PATH}/llvm.cc)
   else()
     add_library(triton SHARED ${PYTHON_SRC_PATH}/main.cc
                     ${PYTHON_SRC_PATH}/ir.cc
@@ -382,19 +473,37 @@ endif()
 
 if(NOT TRITON_BUILD_PYTHON_MODULE)
   foreach(CODEGEN_BACKEND ${TRITON_CODEGEN_BACKENDS})
-    add_subdirectory(3rdparty/triton/third_party/${CODEGEN_BACKEND})
+    if(TRITON_USE_ASCEND)
+      add_subdirectory(3rdparty/triton-ascend/third_party/${CODEGEN_BACKEND})
+    else()
+      add_subdirectory(3rdparty/triton/third_party/${CODEGEN_BACKEND})
+    endif()
   endforeach()
-  add_subdirectory(3rdparty/triton/third_party/proton/dialect)
+  if(TRITON_USE_ASCEND)
+    add_subdirectory(3rdparty/triton-ascend/third_party/proton/Dialect)
+  else()
+    add_subdirectory(3rdparty/triton/third_party/proton/dialect)
+  endif()
 endif()
 
 find_package(Threads REQUIRED)
 
-add_subdirectory(3rdparty/triton/third_party/f2reduce)
-add_subdirectory(3rdparty/triton/bin)
-add_subdirectory(3rdparty/triton/test)
+if(TRITON_USE_ASCEND)
+  add_subdirectory(3rdparty/triton-ascend/third_party/f2reduce)
+  add_subdirectory(3rdparty/triton-ascend/bin)
+  add_subdirectory(3rdparty/triton-ascend/test)
+else()
+  add_subdirectory(3rdparty/triton/third_party/f2reduce)
+  add_subdirectory(3rdparty/triton/bin)
+  add_subdirectory(3rdparty/triton/test)
+endif()
 
 if(TRITON_BUILD_UT)
-  add_subdirectory(3rdparty/triton/unittest)
+  if(TRITON_USE_ASCEND)
+    add_subdirectory(3rdparty/triton-ascend/unittest)
+  else()
+    add_subdirectory(3rdparty/triton/unittest)
+  endif()
   # This target runs all the unit tests.
   add_custom_target(check-triton-unit-tests
     COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,17 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 project(triton CXX C)
 include(CTest)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/triton/cmake")
+option(TRITON_USE_ASCEND "Build the Triton Ascend" OFF)
+
+if(TRITON_USE_ASCEND)
+  add_compile_definitions(TRITON_USE_ASCEND=1)
+endif()
+
+if(TRITON_USE_ASCEND)
+  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/triton-ascend/cmake")
+else()
+  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/triton/cmake")
+endif()
 
 # Options
 option(TRITON_BUILD_PYTHON_MODULE "Build Python Triton bindings" OFF)
@@ -85,7 +95,11 @@ if(TRITON_BUILD_UT)
 endif()
 
 # Compiler flags
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/triton/include)
+if(TRITON_USE_ASCEND)
+  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/triton-ascend/include)
+else()
+  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/triton/include)
+endif()
 if(NOT MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__STDC_FORMAT_MACROS  -fPIC -std=gnu++17")
 else()
@@ -103,7 +117,7 @@ if(NOT MLIR_DIR)
   set(MLIR_DIR ${LLVM_LIBRARY_DIR}/cmake/mlir)
 endif()
 
-if(TRITON_USE_MACA AND NOT LLD_DIR)
+if((TRITON_USE_ASCEND OR TRITON_USE_MACA) AND NOT LLD_DIR)
   set(LLD_DIR ${LLVM_LIBRARY_DIR}/cmake/lld)
 endif()
 
@@ -159,23 +173,57 @@ endif()
 
 include_directories(${PROJECT_SOURCE_DIR}/include)
 include_directories(${PROJECT_BINARY_DIR}/include)
-include_directories(${PROJECT_SOURCE_DIR}/3rdparty/triton)
+if(TRITON_USE_ASCEND)
+  include_directories(${PROJECT_SOURCE_DIR}/3rdparty/triton-ascend)
+else()
+  include_directories(${PROJECT_SOURCE_DIR}/3rdparty/triton)
+endif()
 include_directories(${MLIR_INCLUDE_DIRS})
 include_directories(${LLVM_INCLUDE_DIRS})
-include_directories(${PROJECT_SOURCE_DIR}/3rdparty/triton/include)
-include_directories(${PROJECT_BINARY_DIR}/3rdparty/triton/include) # Tablegen'd files
-include_directories(${PROJECT_SOURCE_DIR}/3rdparty/triton/third_party)
-include_directories(${PROJECT_BINARY_DIR}/3rdparty/triton/third_party) # Tablegen'd files
-# backend
-include_directories(${PROJECT_SOURCE_DIR}/3rdparty/triton/third_party/amd/include)
-include_directories(${PROJECT_SOURCE_DIR}/3rdparty/triton/third_party/nvidia/include)
+if(TRITON_USE_ASCEND)
+  include_directories(${PROJECT_SOURCE_DIR}/3rdparty/triton-ascend/include)
+  include_directories(${PROJECT_BINARY_DIR}/3rdparty/triton-ascend/include) # Tablegen'd files
+  include_directories(${PROJECT_SOURCE_DIR}/3rdparty/triton-ascend/third_party)
+  include_directories(${PROJECT_BINARY_DIR}/3rdparty/triton-ascend/third_party) # Tablegen'd files
+  include_directories(${PROJECT_SOURCE_DIR}/3rdparty/triton-ascend/third_party/ascend/AscendNPU-IR/bishengir/include)
+  include_directories(${PROJECT_BINARY_DIR}/3rdparty/triton-ascend/third_party/ascend/AscendNPU-IR/bishengir/include) # Tablegen'd files
+else()
+  include_directories(${PROJECT_SOURCE_DIR}/3rdparty/triton/include)
+  include_directories(${PROJECT_BINARY_DIR}/3rdparty/triton/include) # Tablegen'd files
+  include_directories(${PROJECT_SOURCE_DIR}/3rdparty/triton/third_party)
+  include_directories(${PROJECT_BINARY_DIR}/3rdparty/triton/third_party) # Tablegen'd files
+  # backend
+  include_directories(${PROJECT_SOURCE_DIR}/3rdparty/triton/third_party/amd/include)
+  include_directories(${PROJECT_SOURCE_DIR}/3rdparty/triton/third_party/nvidia/include)
+endif()
 if(TRITON_USE_MACA)
   include_directories(${PROJECT_SOURCE_DIR}/3rdparty/triton/third_party/metax/include)
 endif()
 
+# Adapter LLVM VERSION For AscendNPU IR
+option(LLVM_MAJOR_VERSION_21_COMPATIBLE "NPUIR build with LLVM 21 or later" OFF)
+if(LLVM_MAJOR_VERSION_21_COMPATIBLE)
+  message(STATUS "[TA]Building AscendNPU IR with LLVM 21 or later")
+  add_definitions(-D__LLVM_MAJOR_VERSION_21_COMPATIBLE__)
+endif()
+
+# Some compatibility changes for LLVM 21 are also needed on LLVM 22.
+# Therefore __LLVM_MAJOR_VERSION_21_COMPATIBLE__ would be enabled too.
+option(LLVM_MAJOR_VERSION_22_COMPATIBLE "NPUIR build with LLVM 22" OFF)
+if(LLVM_MAJOR_VERSION_22_COMPATIBLE)
+  message(STATUS "[TA]Building AscendNPU IR with LLVM 22 or later")
+  add_definitions(-D__LLVM_MAJOR_VERSION_21_COMPATIBLE__)
+  add_definitions(-D__LLVM_MAJOR_VERSION_22_COMPATIBLE__)
+endif()
+
 # link_directories(${LLVM_LIBRARY_DIR})
-add_subdirectory(3rdparty/triton/include)
-add_subdirectory(3rdparty/triton/lib)
+if(TRITON_USE_ASCEND)
+  add_subdirectory(3rdparty/triton-ascend/include)
+  add_subdirectory(3rdparty/triton-ascend/lib)
+else()
+  add_subdirectory(3rdparty/triton/include)
+  add_subdirectory(3rdparty/triton/lib)
+endif()
 add_subdirectory(include)
 add_subdirectory(lib)
 
@@ -194,21 +242,38 @@ endif()
 if(TRITON_BUILD_PYTHON_MODULE)
   message(STATUS "Adding Python module for TritonDistributed")
   set(PYTHON_DIST_SRC_PATH ${CMAKE_CURRENT_SOURCE_DIR}/python/src)
-  add_triton_plugin(TritonDistributed ${PYTHON_DIST_SRC_PATH}/triton_distributed.cc
-                                      ${PYTHON_DIST_SRC_PATH}/passes.cc
-                                      ${PYTHON_DIST_SRC_PATH}/ir.cc)
-
-  target_link_libraries(TritonDistributed PRIVATE DistributedIR SIMTIR ProtonIR Python3::Module pybind11::headers)
+  if(TRITON_USE_ASCEND)
+    add_triton_plugin(TritonDistributed ${PYTHON_DIST_SRC_PATH}/triton_distributed.cc
+                                        ${PYTHON_DIST_SRC_PATH}/ascend_passes.cc
+                                        ${PYTHON_DIST_SRC_PATH}/ir.cc)
+  else()
+    add_triton_plugin(TritonDistributed ${PYTHON_DIST_SRC_PATH}/triton_distributed.cc
+                                        ${PYTHON_DIST_SRC_PATH}/passes.cc
+                                        ${PYTHON_DIST_SRC_PATH}/ir.cc)
+  endif()
+  if(TRITON_USE_ASCEND)
+    target_link_libraries(TritonDistributed PRIVATE DistributedIR Python3::Module pybind11::headers)
+  else()
+    target_link_libraries(TritonDistributed PRIVATE DistributedIR SIMTIR ProtonIR Python3::Module pybind11::headers)
+  endif()
 endif()
 
 if(TRITON_BUILD_PYTHON_MODULE)
   message(STATUS "Adding Python module")
-  set(PYTHON_SRC_PATH ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/triton/python/src)
+  if(TRITON_USE_ASCEND)
+    set(PYTHON_SRC_PATH ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/triton-ascend/python/src)
+  else()
+    set(PYTHON_SRC_PATH ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/triton/python/src)
+  endif()
   include_directories(${PYTHON_SRC_PATH})
 
   # Python Interpreter is used to run lit tests
   find_package(Python3 REQUIRED COMPONENTS Development.Module Interpreter)
   find_package(pybind11 CONFIG REQUIRED HINTS "${Python3_SITELIB}")
+  if(TRITON_USE_ASCEND)
+    include_directories(${Python3_INCLUDE_DIR})
+    include_directories(${pybind11_INCLUDE_DIR})
+  endif()
 
   if (DEFINED TRITON_PLUGIN_DIRS)
     foreach(PLUGIN_DIR ${TRITON_PLUGIN_DIRS})
@@ -228,11 +293,19 @@ if(TRITON_BUILD_PYTHON_MODULE)
   endif()
 
   foreach(CODEGEN_BACKEND ${TRITON_CODEGEN_BACKENDS})
-    add_subdirectory(3rdparty/triton/third_party/${CODEGEN_BACKEND})
+    if(TRITON_USE_ASCEND)
+      add_subdirectory(3rdparty/triton-ascend/third_party/${CODEGEN_BACKEND})
+    else()
+      add_subdirectory(3rdparty/triton/third_party/${CODEGEN_BACKEND})
+    endif()
   endforeach()
 
   if (TRITON_BUILD_PROTON)
-    add_subdirectory(3rdparty/triton/third_party/proton)
+    if(TRITON_USE_ASCEND)
+      add_subdirectory(3rdparty/triton-ascend/third_party/proton)
+    else()
+      add_subdirectory(3rdparty/triton/third_party/proton)
+    endif()
   endif()
   if (TRITON_BUILD_DISTRIBUTED)
     add_subdirectory(csrc)
@@ -241,6 +314,9 @@ if(TRITON_BUILD_PYTHON_MODULE)
   list(APPEND TRITON_PLUGIN_NAMES "proton")
   if(TRITON_USE_MACA)
     add_subdirectory(3rdparty/triton/third_party/proton/Dialect)
+  elseif(TRITON_USE_ASCEND)
+    # We always build proton dialect
+    add_subdirectory(3rdparty/triton-ascend/third_party/proton/Dialect)
   else()
     add_subdirectory(3rdparty/triton/third_party/proton/dialect)
   endif()
@@ -336,6 +412,14 @@ if(TRITON_BUILD_PYTHON_MODULE)
                     ${PYTHON_SRC_PATH}/interpreter.cc
                     ${PYTHON_SRC_PATH}/llvm.cc
                     ${PYTHON_SRC_PATH}/specialize.cc)
+  elseif(TRITON_USE_ASCEND)
+    add_library(triton SHARED ${PYTHON_SRC_PATH}/main.cc
+                ${PYTHON_SRC_PATH}/ir.cc
+                ${PYTHON_SRC_PATH}/../triton/extension/buffer/src/buffer_ir.cc
+                ${PYTHON_SRC_PATH}/gluon_ir.cc
+                ${PYTHON_SRC_PATH}/passes.cc
+                ${PYTHON_SRC_PATH}/interpreter.cc
+                ${PYTHON_SRC_PATH}/llvm.cc)
   else()
     add_library(triton SHARED ${PYTHON_SRC_PATH}/main.cc
                     ${PYTHON_SRC_PATH}/ir.cc
@@ -388,19 +472,37 @@ endif()
 
 if(NOT TRITON_BUILD_PYTHON_MODULE)
   foreach(CODEGEN_BACKEND ${TRITON_CODEGEN_BACKENDS})
-    add_subdirectory(3rdparty/triton/third_party/${CODEGEN_BACKEND})
+    if(TRITON_USE_ASCEND)
+      add_subdirectory(3rdparty/triton-ascend/third_party/${CODEGEN_BACKEND})
+    else()
+      add_subdirectory(3rdparty/triton/third_party/${CODEGEN_BACKEND})
+    endif()
   endforeach()
-  add_subdirectory(3rdparty/triton/third_party/proton/dialect)
+  if(TRITON_USE_ASCEND)
+    add_subdirectory(3rdparty/triton-ascend/third_party/proton/Dialect)
+  else()
+    add_subdirectory(3rdparty/triton/third_party/proton/dialect)
+  endif()
 endif()
 
 find_package(Threads REQUIRED)
 
-add_subdirectory(3rdparty/triton/third_party/f2reduce)
-add_subdirectory(3rdparty/triton/bin)
-add_subdirectory(3rdparty/triton/test)
+if(TRITON_USE_ASCEND)
+  add_subdirectory(3rdparty/triton-ascend/third_party/f2reduce)
+  add_subdirectory(3rdparty/triton-ascend/bin)
+  add_subdirectory(3rdparty/triton-ascend/test)
+else()
+  add_subdirectory(3rdparty/triton/third_party/f2reduce)
+  add_subdirectory(3rdparty/triton/bin)
+  add_subdirectory(3rdparty/triton/test)
+endif()
 
 if(TRITON_BUILD_UT)
-  add_subdirectory(3rdparty/triton/unittest)
+  if(TRITON_USE_ASCEND)
+    add_subdirectory(3rdparty/triton-ascend/unittest)
+  else()
+    add_subdirectory(3rdparty/triton/unittest)
+  endif()
   # This target runs all the unit tests.
   add_custom_target(check-triton-unit-tests
     COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure

--- a/docs/build.md
+++ b/docs/build.md
@@ -179,3 +179,86 @@ and see the following (reduced) output
 ```sh
 ✅ Triton and Torch match
 ```
+
+## To use Triton-distributed with the Ascend backend:
+#### Ascend Build from source
+1. Clone the repo
+```sh
+git clone https://github.com/ByteDance-Seed/Triton-distributed.git
+```
+2. Update submodules
+```sh
+cd Triton-distributed/
+git submodule update --init --depth=1
+cd 3rdparty/triton-ascend
+git submodule update --init --depth=1
+git apply ../triton-ascend.patch
+```
+3. Install dependencies
+
+triton-ascend depends on specified LLVM version
+- step 1：Build LLVM with clang and lld：
+
+  ```bash
+  apt-get install -y clang-15 lld-15 ccache
+  ```
+
+- step 2：set LLVM_INSTALL_PREFIX：
+
+   ```bash
+   export LLVM_INSTALL_PREFIX=/path/to/llvm-install
+   ```
+
+- step 3：Build and Install LLVM：
+
+  ```bash
+  git clone --no-checkout https://github.com/llvm/llvm-project.git
+  cd llvm-project
+  git checkout fad3272286528b8a491085183434c5ad4b59ab92
+  wget https://raw.gitcode.com/Ascend/triton-ascend/blobs/2b0a06eb21438359d6d0576b622e3bb5e0292d17/fad3272.patch
+  git apply fad3272.patch
+  mkdir build
+  cd build
+  cmake ../llvm \
+    -G Ninja \
+    -DCMAKE_C_COMPILER=/usr/bin/clang-15 \
+    -DCMAKE_CXX_COMPILER=/usr/bin/clang++-15 \
+    -DCMAKE_LINKER=/usr/bin/lld-15 \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DLLVM_ENABLE_ASSERTIONS=ON \
+    -DLLVM_ENABLE_PROJECTS="mlir;llvm;lld" \
+    -DLLVM_TARGETS_TO_BUILD="host;NVPTX;AMDGPU" \
+    -DLLVM_ENABLE_LLD=ON \
+    -DCMAKE_INSTALL_PREFIX=${LLVM_INSTALL_PREFIX}
+  ninja install
+  ```
+
+- step 4：copy FileCheck and llvm-lit to Install directory：
+
+   ```bash
+   cp  {PATH_TO}/llvm_project/build/bin/FileCheck ${LLVM_INSTALL_PREFIX}/bin/FileCheck
+   cp  {PATH_TO}/llvm_project/build/bin/llvm-lit ${LLVM_INSTALL_PREFIX}/bin/llvm-lit
+   ```
+4. Build Triton-distributed
+```sh
+cd {PATH_TO}/Triton-distributed
+LLVM_SYSPATH=${LLVM_INSTALL_PREFIX} TRITON_BUILD_WITH_CLANG_LLD=ON TRITON_BUILD_PROTON=OFF TRITON_BUILD_LITTLE_KERNEL=OFF TRITON_USE_ASCEND=ON pip install ./python --verbose --no-build-isolation
+```
+
+5. Build and Install shmem
+```sh
+cd 3rdparty/shmem
+bash scripts/build.sh -python_extension
+pip install dist/shmem-xxx.whl
+```
+### Test Ascend Installation
+#### Allgather GEMM example on single node
+```sh
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+torchrun --nproc-per-node=2 tutorials/11-ascend-allgather-gemm.py
+```
+and see the following (reduced) output
+```sh
+[PASS] Rank0: C_golden and C match within tolerances (rtol=1e-3, atol=1e-3).
+[PASS] Rank1: C_golden and C match within tolerances (rtol=1e-3, atol=1e-3).
+```

--- a/docs/build.md
+++ b/docs/build.md
@@ -179,3 +179,96 @@ and see the following (reduced) output
 ```sh
 ✅ Triton and Torch match
 ```
+
+## To use Triton-distributed with the Ascend backend:
+#### Ascend Build from source
+1. Clone the repo
+```sh
+git clone https://github.com/ByteDance-Seed/Triton-distributed.git
+```
+2. Update submodules
+```sh
+cd Triton-distributed/
+git submodule update --init --depth=1
+cd 3rdparty/triton-ascend
+git submodule update --init --depth=1
+```
+3. Install dependencies
+
+triton-ascend depends on specified LLVM version
+- step 1：Build LLVM with clang and lld：
+
+  ```bash
+  apt-get install -y clang-15 lld-15 ccache
+  ```
+
+- step 2：set LLVM_INSTALL_PREFIX：
+
+   ```bash
+   export LLVM_INSTALL_PREFIX=/path/to/llvm-install
+   ```
+
+- step 3：Build and Install LLVM：
+
+  ```bash
+  git clone --no-checkout https://github.com/llvm/llvm-project.git
+  cd llvm-project
+  git checkout fad3272286528b8a491085183434c5ad4b59ab92
+  wget https://raw.gitcode.com/Ascend/triton-ascend/blobs/2b0a06eb21438359d6d0576b622e3bb5e0292d17/fad3272.patch
+  git apply fad3272.patch
+  mkdir build
+  cd build
+  cmake ../llvm \
+    -G Ninja \
+    -DCMAKE_C_COMPILER=/usr/bin/clang-15 \
+    -DCMAKE_CXX_COMPILER=/usr/bin/clang++-15 \
+    -DCMAKE_LINKER=/usr/bin/lld-15 \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DLLVM_ENABLE_ASSERTIONS=ON \
+    -DLLVM_ENABLE_PROJECTS="mlir;llvm;lld" \
+    -DLLVM_TARGETS_TO_BUILD="host;NVPTX;AMDGPU" \
+    -DLLVM_ENABLE_LLD=ON \
+    -DCMAKE_INSTALL_PREFIX=${LLVM_INSTALL_PREFIX}
+  ninja install
+  ```
+
+- step 4：copy FileCheck and llvm-lit to Install directory：
+
+   ```bash
+   cp  {PATH_TO}/llvm_project/build/bin/FileCheck ${LLVM_INSTALL_PREFIX}/bin/FileCheck
+   cp  {PATH_TO}/llvm_project/build/bin/llvm-lit ${LLVM_INSTALL_PREFIX}/bin/llvm-lit
+   ```
+
+- step 5：build AscendNPU-IR：
+  ```bash
+  source /usr/local/Ascend/ascend-toolkit/set_env.sh
+  git clone https://gitcode.com/Ascend/AscendNPU-IR.git
+  cd AscendNPU-IR
+  git submodule update --init --depth=1
+  mkdir build
+  ./build-tools/build.sh -o ./build -t --build-type Release --apply-patches --bisheng-compile=$ASCEND_HOME_PATH/bin --build-shmem-template
+  ```
+4. Build Triton-distributed
+```sh
+cd {PATH_TO}/Triton-distributed/python
+LLVM_SYSPATH=${LLVM_INSTALL_PREFIX} TRITON_BUILD_WITH_CLANG_LLD=ON TRITON_BUILD_PROTON=OFF TRITON_BUILD_LITTLE_KERNEL=OFF TRITON_USE_ASCEND=ON TRITON_APPEND_CMAKE_ARGS="-DTRITON_BUILD_UT=OFF" python setup.py install
+```
+
+5. Build and Install shmem
+```sh
+cd 3rdparty/shmem
+bash scripts/build.sh -python_extension
+pip install dist/shmem-xxx.whl
+```
+### Test Ascend Installation
+#### Allgather GEMM example on single node
+```sh
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+export PATH=$HOME/AscendNPU-IR/build/bin:$PATH
+torchrun --nproc-per-node=2 tutorials/ascend/01-ascend-allgather-gemm.py
+```
+and see the following (reduced) output
+```sh
+[PASS] Rank0: C_golden and C match within tolerances (rtol=1e-3, atol=1e-3).
+[PASS] Rank1: C_golden and C match within tolerances (rtol=1e-3, atol=1e-3).
+```

--- a/include/TritonDistributed/Conversion/CMakeLists.txt
+++ b/include/TritonDistributed/Conversion/CMakeLists.txt
@@ -1,2 +1,8 @@
-add_subdirectory(TritonDistributedToLLVM)
-add_subdirectory(TritonDistributedToTritonGPU)
+if(NOT TRITON_USE_ASCEND)
+  add_subdirectory(TritonDistributedToLLVM)
+  add_subdirectory(TritonDistributedToTritonGPU)
+endif()
+
+if(TRITON_USE_ASCEND)
+  add_subdirectory(TritonDistributedToHIVM)
+endif()

--- a/include/TritonDistributed/Conversion/TritonDistributedToHIVM/CMakeLists.txt
+++ b/include/TritonDistributed/Conversion/TritonDistributedToHIVM/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls --name TritonDistributedToHIVM)
+add_public_tablegen_target(TritonDistributedToHIVMConversionPassIncGen)

--- a/include/TritonDistributed/Conversion/TritonDistributedToHIVM/Passes.h
+++ b/include/TritonDistributed/Conversion/TritonDistributedToHIVM/Passes.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef TRITON_DISTRIBUTED_TO_HIVM_CONVERSION_PASSES_H
+#define TRITON_DISTRIBUTED_TO_HIVM_CONVERSION_PASSES_H
+#include "bishengir/Dialect/HIVM/IR/HIVM.h"
+#include "mlir/Pass/Pass.h"
+
+#include "TritonDistributed/Conversion/TritonDistributedToHIVM/TritonDistributedToHIVMPass.h"
+
+namespace mlir {
+namespace triton {
+
+#define GEN_PASS_DECL
+#include "TritonDistributed/Conversion/TritonDistributedToHIVM/Passes.h.inc"
+
+#define GEN_PASS_REGISTRATION
+#include "TritonDistributed/Conversion/TritonDistributedToHIVM/Passes.h.inc"
+
+} // namespace triton
+} // namespace mlir
+
+#endif

--- a/include/TritonDistributed/Conversion/TritonDistributedToHIVM/Passes.td
+++ b/include/TritonDistributed/Conversion/TritonDistributedToHIVM/Passes.td
@@ -1,0 +1,26 @@
+//
+// Modification Copyright 2026 Huawei Technologies Ltd. and/or its affiliates.
+//
+#ifndef TRITONDISTRIBUTED_HIVM_CONVERSION_PASSES
+#define TRITONDISTRIBUTED_HIVM_CONVERSION_PASSES
+
+include "mlir/Pass/PassBase.td"
+
+// ASCEND Backend
+def ConvertTritonDistributedToHIVM : Pass<"convert-triton-distributed-to-hivm", "mlir::ModuleOp"> {
+    let summary = "Convert TritonDistributed to HIVM";
+    let description = [{
+        This pass converts TritonDistributed Dialect operations to hivm.custom operations.
+    }];
+    let constructor = "mlir::triton::ASCEND::createConvertTritonDistributedToHIVMPass()";
+
+    let dependentDialects = ["hivm::HIVMDialect",
+                             "triton::distributed::DistributedDialect"];
+
+    let options = [
+        Option<"patternBenefitPrioritizeOverLLVMConversions", "pattern-benefit-prioritize-over-llvm-conversions",
+               "int", /*default*/"10",
+               "pattern benefit to prioritize over LLVM conversions">,
+    ];
+}
+#endif // TRITONDISTRIBUTED_HIVM_CONVERSION_PASSES

--- a/include/TritonDistributed/Conversion/TritonDistributedToHIVM/TritonDistributedToHIVMPass.h
+++ b/include/TritonDistributed/Conversion/TritonDistributedToHIVM/TritonDistributedToHIVMPass.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef TRITON_DISTRIBUTED_CONVERSION_TRITONDISTRIBUTEDTOHIVM_H
+#define TRITON_DISTRIBUTED_CONVERSION_TRITONDISTRIBUTEDTOHIVM_H
+
+#include "bishengir/Dialect/HIVM/IR/HIVM.h"
+#include "mlir/IR/PatternMatch.h"
+#include <memory>
+
+namespace mlir {
+class ModuleOp;
+template <typename T> class OperationPass;
+
+namespace triton {
+
+namespace ASCEND {
+static const llvm::SmallVector<std::string> mixTypeList = {
+    "aclshmem_barrier_all", "aclshmem_barrier"};
+static const llvm::SmallVector<std::string> vecTypeList = {
+    "aclshmemx_barrier_all_vec"};
+static const llvm::DenseMap<llvm::StringRef, hivm::PIPE> pipeMap;
+static const int distributedDialectPrefixLen = 12;
+void populateDistributedOpToHIVMPatterns(RewritePatternSet &patterns,
+                                         PatternBenefit benefit);
+std::unique_ptr<OperationPass<ModuleOp>>
+createConvertTritonDistributedToHIVMPass();
+} // namespace ASCEND
+
+} // namespace triton
+} // namespace mlir
+
+#endif

--- a/include/TritonDistributed/Conversion/TritonDistributedToHIVM/TritonDistributedToHIVMPass.h
+++ b/include/TritonDistributed/Conversion/TritonDistributedToHIVM/TritonDistributedToHIVMPass.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef TRITON_DISTRIBUTED_CONVERSION_TRITONDISTRIBUTEDTOHIVM_H
+#define TRITON_DISTRIBUTED_CONVERSION_TRITONDISTRIBUTEDTOHIVM_H
+
+#include "bishengir/Dialect/HIVM/IR/HIVM.h"
+#include "mlir/IR/PatternMatch.h"
+#include <memory>
+
+namespace mlir {
+class ModuleOp;
+template <typename T> class OperationPass;
+
+namespace triton {
+
+namespace ASCEND {
+static const llvm::SmallVector<std::string> mixTypeList = {
+    "aclshmem_barrier_all"};
+static const llvm::SmallVector<std::string> vecTypeList = {
+    "aclshmemx_barrier_all_vec"};
+static const llvm::SmallVector<std::string> sideEffectSymbols = {
+    "aclshmemx_barrier_all_vec", "aclshmem_barrier_all", "aclshmem_int8_p",
+    "aclshmem_int16_p",          "aclshmem_int32_p",     "aclshmem_int64_p"};
+static const llvm::DenseMap<llvm::StringRef, hivm::PIPE> pipeMap;
+static const int distributedDialectPrefixLen = 12;
+void populateDistributedOpToHIVMPatterns(RewritePatternSet &patterns,
+                                         PatternBenefit benefit, bool existDot);
+std::unique_ptr<OperationPass<ModuleOp>>
+createConvertTritonDistributedToHIVMPass();
+} // namespace ASCEND
+
+} // namespace triton
+} // namespace mlir
+
+#endif

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -1,2 +1,8 @@
-add_subdirectory(TritonDistributedToLLVM)
-add_subdirectory(TritonDistributedToTritonGPU)
+if(NOT TRITON_USE_ASCEND)
+  add_subdirectory(TritonDistributedToLLVM)
+  add_subdirectory(TritonDistributedToTritonGPU)
+endif()
+
+if(TRITON_USE_ASCEND)
+  add_subdirectory(TritonDistributedToHIVM)
+endif()

--- a/lib/Conversion/TritonDistributedToHIVM/ASCEND/ConvertTritonDistributedToHIVM.cpp
+++ b/lib/Conversion/TritonDistributedToHIVM/ASCEND/ConvertTritonDistributedToHIVM.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include "TritonDistributed/Conversion/TritonDistributedToHIVM/Passes.h"
+#include "TritonDistributed/Dialect/Distributed/IR/Dialect.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir {
+namespace triton {
+#define GEN_PASS_DEF_CONVERTTRITONDISTRIBUTEDTOHIVM
+#include "TritonDistributed/Conversion/TritonDistributedToHIVM/Passes.h.inc"
+} // namespace triton
+} // namespace mlir
+
+using namespace mlir;
+using namespace mlir::triton;
+
+namespace {
+
+struct ConvertTritonDistributedToHIVM
+    : public triton::impl::ConvertTritonDistributedToHIVMBase<
+          ConvertTritonDistributedToHIVM> {
+  using ConvertTritonDistributedToHIVMBase::ConvertTritonDistributedToHIVMBase;
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    ModuleOp mod = getOperation();
+
+    RewritePatternSet patterns(context);
+    int benefit = patternBenefitPrioritizeOverLLVMConversions;
+
+    // Populate patterns to convert distributed ops to hivm.custom
+    mlir::triton::ASCEND::populateDistributedOpToHIVMPatterns(patterns,
+                                                              benefit);
+
+    if (failed(applyPatternsGreedily(mod, std::move(patterns))))
+      return signalPassFailure();
+  }
+};
+
+} // anonymous namespace
+
+namespace mlir {
+namespace triton {
+
+std::unique_ptr<OperationPass<ModuleOp>>
+ASCEND::createConvertTritonDistributedToHIVMPass() {
+  return std::make_unique<ConvertTritonDistributedToHIVM>();
+}
+
+} // namespace triton
+} // namespace mlir

--- a/lib/Conversion/TritonDistributedToHIVM/ASCEND/ConvertTritonDistributedToHIVM.cpp
+++ b/lib/Conversion/TritonDistributedToHIVM/ASCEND/ConvertTritonDistributedToHIVM.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include "TritonDistributed/Conversion/TritonDistributedToHIVM/Passes.h"
+#include "TritonDistributed/Dialect/Distributed/IR/Dialect.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir {
+namespace triton {
+#define GEN_PASS_DEF_CONVERTTRITONDISTRIBUTEDTOHIVM
+#include "TritonDistributed/Conversion/TritonDistributedToHIVM/Passes.h.inc"
+} // namespace triton
+} // namespace mlir
+
+using namespace mlir;
+using namespace mlir::triton;
+
+namespace {
+
+struct ConvertTritonDistributedToHIVM
+    : public triton::impl::ConvertTritonDistributedToHIVMBase<
+          ConvertTritonDistributedToHIVM> {
+  using ConvertTritonDistributedToHIVMBase::ConvertTritonDistributedToHIVMBase;
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    ModuleOp mod = getOperation();
+    // Check if the kernel contains tl.dot. Without tl.dot,
+    // the kernel would be pure AIV kernel.
+    bool existDot = false;
+    mod.walk([&](Operation *op) {
+      if (llvm::isa<triton::DotOp, triton::DotScaledOp>(op)) {
+        existDot = true;
+        return WalkResult::interrupt();
+      }
+      return WalkResult::advance();
+    });
+    RewritePatternSet patterns(context);
+    int benefit = patternBenefitPrioritizeOverLLVMConversions;
+
+    // Populate patterns to convert distributed ops to hivm.custom
+    mlir::triton::ASCEND::populateDistributedOpToHIVMPatterns(patterns, benefit,
+                                                              existDot);
+
+    if (failed(applyPatternsGreedily(mod, std::move(patterns))))
+      return signalPassFailure();
+  }
+};
+
+} // anonymous namespace
+
+namespace mlir {
+namespace triton {
+
+std::unique_ptr<OperationPass<ModuleOp>>
+ASCEND::createConvertTritonDistributedToHIVMPass() {
+  return std::make_unique<ConvertTritonDistributedToHIVM>();
+}
+
+} // namespace triton
+} // namespace mlir

--- a/lib/Conversion/TritonDistributedToHIVM/ASCEND/DistributedOpToHIVM.cpp
+++ b/lib/Conversion/TritonDistributedToHIVM/ASCEND/DistributedOpToHIVM.cpp
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include "TritonDistributed/Conversion/TritonDistributedToHIVM/TritonDistributedToHIVMPass.h"
+#include "TritonDistributed/Dialect/Distributed/IR/Dialect.h"
+#include "ascend/include/Utils/Utils.h"
+#include "bishengir/Dialect/Annotation/IR/Annotation.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/DialectRegistry.h"
+#include "mlir/IR/SymbolTable.h"
+#include "mlir/IR/Value.h"
+#include "mlir/IR/ValueRange.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/Casting.h"
+#include <string>
+#include <type_traits>
+
+using namespace mlir;
+using namespace mlir::triton;
+
+namespace {
+
+/// Generic template pattern to convert distributed ops to hivm.custom
+/// The callee name is derived from the distributed op name with a prefix
+template <typename DistOp>
+class DistributedOpToHIVM : public OpRewritePattern<DistOp> {
+public:
+  using OpAdaptor = typename DistOp::Adaptor;
+
+  DistributedOpToHIVM(MLIRContext *context, StringRef customPrefix = "",
+                      PatternBenefit benefit = PatternBenefit(1))
+      : OpRewritePattern<DistOp>(context, benefit), customPrefix(customPrefix) {
+  }
+
+  void inferCoreType(DistOp op) const {
+    if constexpr (std::is_same_v<DistOp, distributed::ExternCallOp>) {
+      auto externCallOp = llvm::cast<distributed::ExternCallOp>(op);
+      if (llvm::is_contained(ASCEND::mixTypeList, externCallOp.getSymbol())) {
+        op->setAttr(hivm::TCoreTypeAttr::name,
+                    hivm::TCoreTypeAttr::get(op->getContext(),
+                                             hivm::TCoreType::CUBE_AND_VECTOR));
+        return;
+      }
+      if (llvm::is_contained(ASCEND::vecTypeList, externCallOp.getSymbol())) {
+        op->setAttr(hivm::TCoreTypeAttr::name,
+                    hivm::TCoreTypeAttr::get(op->getContext(),
+                                             hivm::TCoreType::VECTOR));
+        return;
+      }
+    }
+    op->setAttr(hivm::TCoreTypeAttr::name,
+                hivm::TCoreTypeAttr::get(op->getContext(),
+                                         hivm::TCoreType::CUBE_OR_VECTOR));
+  }
+
+  std::string getTypeName(Type type) const {
+    if (auto fpTy = llvm::dyn_cast<FloatType>(type)) {
+      if (fpTy.isBF16()) {
+        return "bfloat16";
+      } else if (fpTy.isF16()) {
+        return "half";
+      } else if (fpTy.isF32()) {
+        return "float";
+      }
+    }
+    if (auto intTy = llvm::dyn_cast<IntegerType>(type)) {
+      switch (intTy.getWidth()) {
+      case 8:
+        return "int8";
+      case 16:
+        return "int16";
+      case 32:
+        return "int32";
+      case 64:
+        return "int64";
+      }
+    }
+    assert(false && "unsupport type");
+  }
+
+  LogicalResult matchAndRewrite(DistOp op,
+                                PatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    inferCoreType(op);
+    std::string symbolName;
+    if (auto sym = op->template getAttrOfType<StringAttr>("symbol")) {
+      symbolName = sym.str();
+    }
+
+    llvm::TypeSwitch<Operation *, void>(op)
+        .Case([&](distributed::SymmAtOp) {
+          auto elemTy = llvm::cast<triton::PointerType>(op->getOperand(0).getType())
+                            .getPointeeType();
+          symbolName = "aclshmem_" + getTypeName(elemTy) + "_ptr";
+        })
+        .Case([&](distributed::GetRankOp) {
+          symbolName = "aclshmem_my_pe";
+        })
+        .Case([&](distributed::GetNumRanksOp) {
+          symbolName = "aclshmem_n_pes";
+        })
+        .Case([&](distributed::NotifyOp notifyOp) {
+          auto typeName = getTypeName(notifyOp.getSignalVal().getType());
+          symbolName = "aclshmem_" + typeName + "_p";
+        });
+
+    if (symbolName == "aclshmem_ptr") {
+      auto elemTy = llvm::cast<triton::PointerType>(op->getOperand(0).getType())
+                        .getPointeeType();
+      symbolName = "aclshmem_" + getTypeName(elemTy) + "_ptr";
+    }
+
+    if (symbolName.empty()) {
+      symbolName = op->getName().getStringRef().drop_front(
+          ASCEND::distributedDialectPrefixLen);
+    }
+    std::string customName = customPrefix + "." + symbolName;
+    auto operands = op->getOperands();
+    llvm::SmallVector<Value> customResults;
+    for (auto res : op->getResults()) {
+      if (auto tensorTy = llvm::dyn_cast<RankedTensorType>(res.getType())) {
+        auto emptyOp = rewriter.create<tensor::EmptyOp>(
+            op->getLoc(), tensorTy.getShape(), tensorTy.getElementType());
+        customResults.emplace_back(emptyOp);
+      }
+    }
+    auto customOp =
+        rewriter.create<hivm::CustomOp>(loc, op->getResultTypes(), customName,
+                                        operands, customResults, ValueRange{});
+    customOp->setAttrs(op->getAttrs());
+    customOp->setAttr("hivm.is_distributed", rewriter.getUnitAttr());
+    auto pipePair = ASCEND::pipeMap.find(customName);
+    if (pipePair != ASCEND::pipeMap.end()) {
+      customOp.setPipe(pipePair->getSecond());
+    } else {
+      customOp.setPipe(hivm::PIPE::PIPE_S);
+    }
+    customOp.setVFMode(hivm::VFMode::SIMD);
+    customOp->setAttr("symbol", rewriter.getStringAttr(symbolName));
+    if (llvm::isa<distributed::ConsumeTokenOp>(op) &&
+        llvm::isa<RankedTensorType>(customOp->getResult(0).getType())) {
+      auto annotationOp = rewriter.create<annotation::MarkOp>(
+          op->getLoc(), customOp->getResult(0));
+      annotationOp->setAttr(ConverterUtils::continuousAttrName,
+                            rewriter.getUnitAttr());
+      customOp->setAttr(ConverterUtils::customSrcPtrIndexAttrName,
+                        rewriter.getDenseI32ArrayAttr({0}));
+    }
+    // Replace the original op with the custom op
+    if (op->getNumResults() == 0) {
+      rewriter.eraseOp(op);
+    } else {
+      rewriter.replaceOp(op, customOp);
+    }
+
+    return success();
+  }
+
+private:
+  std::string customPrefix;
+};
+
+/// Helper function to register distributed op to hivm.custom patterns
+template <typename... Args>
+void registerDistributedOpToHIVM(RewritePatternSet &patterns,
+                                 StringRef calleePrefix = "",
+                                 PatternBenefit benefit = PatternBenefit(1)) {
+  patterns.add<DistributedOpToHIVM<Args>...>(patterns.getContext(),
+                                             calleePrefix, benefit);
+}
+
+} // namespace
+
+/// Populate the pattern set with distributed op to hivm.custom patterns
+void mlir::triton::ASCEND::populateDistributedOpToHIVMPatterns(
+    RewritePatternSet &patterns, PatternBenefit benefit) {
+  // Use the template function to register all distributed ops
+  // All ops convert to hivm.custom with the name "dist.<op_name>"
+  registerDistributedOpToHIVM<distributed::GetRankOp,
+                              distributed::GetNumRanksOp, distributed::SymmAtOp,
+                              distributed::WaitOp, distributed::ConsumeTokenOp,
+                              distributed::NotifyOp, distributed::ExternCallOp>(
+      patterns, "dist", benefit);
+}

--- a/lib/Conversion/TritonDistributedToHIVM/ASCEND/DistributedOpToHIVM.cpp
+++ b/lib/Conversion/TritonDistributedToHIVM/ASCEND/DistributedOpToHIVM.cpp
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include "TritonDistributed/Conversion/TritonDistributedToHIVM/TritonDistributedToHIVMPass.h"
+#include "TritonDistributed/Dialect/Distributed/IR/Dialect.h"
+#include "ascend/include/Utils/Utils.h"
+#include "bishengir/Dialect/Annotation/IR/Annotation.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/DialectRegistry.h"
+#include "mlir/IR/SymbolTable.h"
+#include "mlir/IR/Value.h"
+#include "mlir/IR/ValueRange.h"
+#include "triton/Dialect/Triton/IR/Types.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/Casting.h"
+#include <string>
+#include <type_traits>
+
+using namespace mlir;
+using namespace mlir::triton;
+
+namespace {
+
+/// Generic template pattern to convert distributed ops to hivm.custom
+/// The callee name is derived from the distributed op name with a prefix
+template <typename DistOp>
+class DistributedOpToHIVM : public OpRewritePattern<DistOp> {
+public:
+  using OpAdaptor = typename DistOp::Adaptor;
+
+  DistributedOpToHIVM(MLIRContext *context, bool existDot = false,
+                      StringRef customPrefix = "",
+                      PatternBenefit benefit = PatternBenefit(1))
+      : OpRewritePattern<DistOp>(context, benefit), existDotFlag(existDot),
+        customPrefix(customPrefix) {}
+
+  void inferCoreType(DistOp op) const {
+    if constexpr (std::is_same_v<DistOp, distributed::ExternCallOp>) {
+      auto externCallOp = llvm::cast<distributed::ExternCallOp>(op);
+      if (llvm::is_contained(ASCEND::vecTypeList, externCallOp.getSymbol())) {
+        op->setAttr(hivm::TCoreTypeAttr::name,
+                    hivm::TCoreTypeAttr::get(op->getContext(),
+                                             hivm::TCoreType::VECTOR));
+        return;
+      }
+      if (llvm::is_contained(ASCEND::mixTypeList, externCallOp.getSymbol())) {
+        op->setAttr(hivm::TCoreTypeAttr::name,
+                    hivm::TCoreTypeAttr::get(op->getContext(),
+                                             hivm::TCoreType::CUBE_AND_VECTOR));
+        return;
+      }
+    }
+    auto coreType = existDotFlag ? hivm::TCoreType::CUBE_AND_VECTOR
+                                 : hivm::TCoreType::VECTOR;
+    op->setAttr(hivm::TCoreTypeAttr::name,
+                hivm::TCoreTypeAttr::get(op->getContext(), coreType));
+  }
+
+  std::string getTypeName(Type type) const {
+    if (auto fpTy = llvm::dyn_cast<FloatType>(type)) {
+      if (fpTy.isBF16()) {
+        return "bfloat16";
+      } else if (fpTy.isF16()) {
+        return "half";
+      } else if (fpTy.isF32()) {
+        return "float";
+      }
+    }
+    if (auto intTy = llvm::dyn_cast<IntegerType>(type)) {
+      switch (intTy.getWidth()) {
+      case 8:
+        return "int8";
+      case 16:
+        return "int16";
+      case 32:
+        return "int32";
+      case 64:
+        return "int64";
+      }
+    }
+    if (auto pointerTy = llvm::dyn_cast<PointerType>(type)) {
+      return getTypeName(pointerTy.getPointeeType()) + "_ptr_1d";
+    }
+    if (auto tensorTy = llvm::dyn_cast<RankedTensorType>(type)) {
+      auto pointerTy = llvm::cast<PointerType>(tensorTy.getElementType());
+      return getTypeName(pointerTy.getPointeeType()) + "_ptr_" +
+             char('0' + tensorTy.getRank()) + "d";
+    }
+    assert(false && "unsupport type");
+  }
+
+  LogicalResult matchAndRewrite(DistOp op,
+                                PatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    inferCoreType(op);
+    std::string symbolName;
+    if (auto sym = op->template getAttrOfType<StringAttr>("symbol")) {
+      symbolName = sym.str();
+    }
+    bool hasSideEffect = true;
+
+    llvm::TypeSwitch<Operation *, void>(op)
+        .Case([&](distributed::SymmAtOp) {
+          auto elemTy =
+              llvm::cast<triton::PointerType>(op->getOperand(0).getType())
+                  .getPointeeType();
+          symbolName = "aclshmem_ptr_" + getTypeName(elemTy);
+        })
+        .Case([&](distributed::GetRankOp) { symbolName = "aclshmem_my_pe"; })
+        .Case(
+            [&](distributed::GetNumRanksOp) { symbolName = "aclshmem_n_pes"; })
+        .Case([&](distributed::NotifyOp notifyOp) {
+          auto typeName = getTypeName(notifyOp.getSignalVal().getType());
+          symbolName = "aclshmem_" + typeName + "_p";
+        })
+        .Case([&](distributed::ConsumeTokenOp consumeTokenOp) {
+          auto typeName = getTypeName(consumeTokenOp.getInput().getType());
+          symbolName = "aclshmem_consume_token_" + typeName;
+        })
+        .Case([&](distributed::WaitOp waitOp) {
+          auto typeName = getTypeName(
+              llvm::cast<PointerType>(waitOp.getBarrierPtr().getType())
+                  .getPointeeType());
+          symbolName = "aclshmem_wait_" + typeName;
+        });
+
+    if (symbolName == "aclshmem_ptr") {
+      auto elemTy = llvm::cast<triton::PointerType>(op->getOperand(0).getType())
+                        .getPointeeType();
+      symbolName = "aclshmem_ptr_" + getTypeName(elemTy);
+    }
+
+    if (symbolName.empty()) {
+      symbolName = op->getName().getStringRef().drop_front(
+          ASCEND::distributedDialectPrefixLen);
+    }
+    if (!llvm::is_contained(ASCEND::sideEffectSymbols, symbolName)) {
+      hasSideEffect = false;
+    }
+    std::string customName = customPrefix + "." + symbolName;
+    ValueRange operands = op->getOperands();
+    if (symbolName == "aclshmem_my_pe" || symbolName == "aclshmem_n_pes") {
+      // TODO: Support device mesh
+      operands = ValueRange();
+    }
+    llvm::SmallVector<Value> customResults;
+    for (auto res : op->getResults()) {
+      if (auto tensorTy = llvm::dyn_cast<RankedTensorType>(res.getType())) {
+        auto emptyOp = rewriter.create<tensor::EmptyOp>(
+            op->getLoc(), tensorTy.getShape(), tensorTy.getElementType());
+        customResults.emplace_back(emptyOp);
+      }
+    }
+    auto customOp =
+        rewriter.create<hivm::CustomOp>(loc, op->getResultTypes(), customName,
+                                        operands, customResults, ValueRange{});
+    customOp->setAttrs(op->getAttrs());
+    customOp->setAttr("hivm.is_distributed", rewriter.getUnitAttr());
+    auto pipePair = ASCEND::pipeMap.find(customName);
+    if (pipePair != ASCEND::pipeMap.end()) {
+      customOp.setPipe(pipePair->getSecond());
+    } else {
+      customOp.setPipe(hivm::PIPE::PIPE_S);
+    }
+    customOp.setVFMode(hivm::VFMode::SIMD);
+    customOp->setAttr("symbol", rewriter.getStringAttr(symbolName));
+    if (llvm::isa<distributed::ConsumeTokenOp>(op) &&
+        llvm::isa<RankedTensorType>(customOp->getResult(0).getType())) {
+      auto annotationOp = rewriter.create<annotation::MarkOp>(
+          op->getLoc(), customOp->getResult(0));
+      annotationOp->setAttr(ConverterUtils::continuousAttrName,
+                            rewriter.getUnitAttr());
+      customOp->setAttr(ConverterUtils::customSrcPtrIndexAttrName,
+                        rewriter.getDenseI32ArrayAttr({0}));
+    }
+    if (!hasSideEffect) {
+      customOp->setAttr("no_side_effect", rewriter.getUnitAttr());
+    }
+    // Replace the original op with the custom op
+    if (op->getNumResults() == 0) {
+      rewriter.eraseOp(op);
+    } else {
+      rewriter.replaceOp(op, customOp);
+    }
+
+    return success();
+  }
+
+private:
+  std::string customPrefix;
+  bool existDotFlag;
+};
+
+/// Helper function to register distributed op to hivm.custom patterns
+template <typename... Args>
+void registerDistributedOpToHIVM(RewritePatternSet &patterns, bool existDot,
+                                 StringRef calleePrefix = "",
+                                 PatternBenefit benefit = PatternBenefit(1)) {
+  patterns.add<DistributedOpToHIVM<Args>...>(patterns.getContext(), existDot,
+                                             calleePrefix, benefit);
+}
+
+} // namespace
+
+/// Populate the pattern set with distributed op to hivm.custom patterns
+void mlir::triton::ASCEND::populateDistributedOpToHIVMPatterns(
+    RewritePatternSet &patterns, PatternBenefit benefit, bool existDot) {
+  // Use the template function to register all distributed ops
+  // All ops convert to hivm.custom with the name "dist.<op_name>"
+  registerDistributedOpToHIVM<distributed::GetRankOp,
+                              distributed::GetNumRanksOp, distributed::SymmAtOp,
+                              distributed::WaitOp, distributed::ConsumeTokenOp,
+                              distributed::NotifyOp, distributed::ExternCallOp>(
+      patterns, existDot, "dist", benefit);
+}

--- a/lib/Conversion/TritonDistributedToHIVM/CMakeLists.txt
+++ b/lib/Conversion/TritonDistributedToHIVM/CMakeLists.txt
@@ -1,0 +1,12 @@
+
+add_triton_library(TritonDistributedToHIVM
+    ASCEND/DistributedOpToHIVM.cpp
+    ASCEND/ConvertTritonDistributedToHIVM.cpp
+
+    DEPENDS
+    TritonDistributedToHIVMConversionPassIncGen
+
+    LINK_LIBS PUBLIC
+    DistributedIR
+    BiShengIRHIVMDialect
+)

--- a/python/setup.py
+++ b/python/setup.py
@@ -102,7 +102,8 @@ class BackendInstaller:
     def prepare(backend_name: str, backend_src_dir: str = None, is_external: bool = False):
         # Initialize submodule if there is one for in-tree backends.
         if not is_external:
-            root_dir = os.path.join(get_base_dir(), "3rdparty", "triton", "third_party")
+            triton_subdir = "triton-ascend" if check_env_flag("TRITON_USE_ASCEND", "OFF") else "triton"
+            root_dir = os.path.join(get_base_dir(), "3rdparty", triton_subdir, "third_party")
             assert backend_name in os.listdir(
                 root_dir), f"{backend_name} is requested for install but not present in {root_dir}"
 
@@ -131,7 +132,8 @@ class BackendInstaller:
         for file in ["compiler.py", "driver.py"]:
             assert os.path.exists(os.path.join(backend_path, file)), f"${file} does not exist in ${backend_path}"
 
-        install_dir = os.path.join(os.path.dirname(__file__), os.pardir, "3rdparty", "triton", "python", "triton",
+        triton_subdir = "triton-ascend" if check_env_flag("TRITON_USE_ASCEND", "OFF") else "triton"
+        install_dir = os.path.join(os.path.dirname(__file__), os.pardir, "3rdparty", triton_subdir, "python", "triton",
                                    "backends", backend_name)
 
         dist_backend_path = None
@@ -274,7 +276,8 @@ def get_llvm_package_info():
         return Package("llvm", "LLVM-C.lib", "", "LLVM_INCLUDE_DIRS", "LLVM_LIBRARY_DIR", "LLVM_SYSPATH")
     # use_assert_enabled_llvm = check_env_flag("TRITON_USE_ASSERT_ENABLED_LLVM", "False")
     # release_suffix = "assert" if use_assert_enabled_llvm else "release"
-    llvm_hash_path = os.path.join(get_base_dir(), "3rdparty", "triton", "cmake", "llvm-hash.txt")
+    triton_subdir = "triton-ascend" if check_env_flag("TRITON_USE_ASCEND", "OFF") else "triton"
+    llvm_hash_path = os.path.join(get_base_dir(), "3rdparty", triton_subdir, "cmake", "llvm-hash.txt")
     with open(llvm_hash_path, "r") as llvm_hash_file:
         rev = llvm_hash_file.read(8)
     name = f"llvm-{rev}-{system_suffix}"
@@ -386,7 +389,8 @@ def download_and_copy(name, src_func, dst_path, variable, version, url_func):
     url = url_func(supported[system], arch, version)
     src_path = src_func(supported[system], arch, version)
     tmp_path = os.path.join(triton_cache_path, "nvidia", name)  # path to cache the download
-    dst_path = os.path.join(base_dir, os.pardir, "3rdparty", "triton", "third_party", "nvidia", "backend",
+    triton_subdir = "triton-ascend" if check_env_flag("TRITON_USE_ASCEND", "OFF") else "triton"
+    dst_path = os.path.join(base_dir, os.pardir, "3rdparty", triton_subdir, "third_party", "nvidia", "backend",
                             dst_path)  # final binary path
     src_path = os.path.join(tmp_path, src_path)
     download = not os.path.exists(src_path)
@@ -596,14 +600,15 @@ class CMakeBuild(build_ext):
     def get_proton_cmake_args(self):
         cmake_args = get_thirdparty_packages([get_json_package_info()])
         cmake_args += self.get_pybind11_cmake_args()
+        triton_subdir = "triton-ascend" if check_env_flag("TRITON_USE_ASCEND", "OFF") else "triton"
         cupti_include_dir = get_env_with_keys(["TRITON_CUPTI_INCLUDE_PATH"])
         if cupti_include_dir == "":
-            cupti_include_dir = os.path.join(get_base_dir(), "3rdparty", "triton", "third_party", "nvidia", "backend",
+            cupti_include_dir = os.path.join(get_base_dir(), "3rdparty", triton_subdir, "third_party", "nvidia", "backend",
                                              "include")
         cmake_args += ["-DCUPTI_INCLUDE_DIR=" + cupti_include_dir]
         roctracer_include_dir = get_env_with_keys(["TRITON_ROCTRACER_INCLUDE_PATH"])
         if roctracer_include_dir == "":
-            roctracer_include_dir = os.path.join(get_base_dir(), "3rdparty", "triton", "third_party", "amd", "backend",
+            roctracer_include_dir = os.path.join(get_base_dir(), "3rdparty", triton_subdir, "third_party", "amd", "backend",
                                                  "include")
         cmake_args += ["-DROCTRACER_INCLUDE_DIR=" + roctracer_include_dir]
         return cmake_args
@@ -689,6 +694,7 @@ class CMakeBuild(build_ext):
             "TRITON_BUILD_DISTRIBUTED",
             "TRITON_BUILD_WITH_CCACHE",
             "TRITON_PARALLEL_LINK_JOBS",
+            "TRITON_USE_ASCEND",
         ]
         cmake_args += [f"-D{option}={os.getenv(option)}" for option in passthrough_args if option in os.environ]
 
@@ -706,6 +712,10 @@ class CMakeBuild(build_ext):
         if cmake_args_append is not None:
             cmake_args += shlex.split(cmake_args_append)
 
+        # LLVM version compatibility for Ascend
+        if check_env_flag("TRITON_USE_ASCEND", "OFF"):
+            cmake_args += ["-DLLVM_MAJOR_VERSION_22_COMPATIBLE=ON"]
+
         # USE MACA
         if _is_maca_platform() and check_env_flag("TRITON_USE_MACA", "OFF"):  # Default OFF
             cmake_args += ["-DTRITON_USE_MACA=ON"]
@@ -718,8 +728,29 @@ class CMakeBuild(build_ext):
         subprocess.check_call(["cmake", "--build", "."] + build_args, cwd=cmake_dir)
         subprocess.check_call(["cmake", "--build", ".", "--target", "mlir-doc"], cwd=cmake_dir)
 
+        if check_env_flag("TRITON_USE_ASCEND", "OFF"):
+            # Copy triton-mlir-opt tool to extdir for runtime use
+            # This tool is needed for converting MLIR to Bytecode
+            triton_mlir_opt_src = os.path.join(
+                cmake_dir, "3rdparty", "triton-ascend", "bin", "triton-mlir-opt"
+            )
+            if os.path.exists(triton_mlir_opt_src):
+                triton_mlir_opt_dst = os.path.join(extdir, "triton-mlir-opt")
+                shutil.copy2(triton_mlir_opt_src, triton_mlir_opt_dst)
+                # Make it executable (Unix-like systems)
+                if platform.system() != "Windows":
+                    os.chmod(triton_mlir_opt_dst, 0o755)
+                    # Strip debug symbols to reduce binary size (can reduce size by ~80%)
+                    try:
+                        subprocess.check_call(["strip", "--strip-all", triton_mlir_opt_dst])
+                        print("Stripped triton-mlir-opt to reduce size")
+                    except (subprocess.CalledProcessError, FileNotFoundError):
+                        # strip command not available or failed, continue without stripping
+                        pass
+                print(f"Copied triton-mlir-opt to {triton_mlir_opt_dst}")
 
-nvidia_version_path = os.path.join(get_base_dir(), "3rdparty", "triton", "cmake", "nvidia-toolchain-version.json")
+
+nvidia_version_path = os.path.join(get_base_dir(), "3rdparty", "triton-ascend" if check_env_flag("TRITON_USE_ASCEND", "OFF") else "triton", "cmake", "nvidia-toolchain-version.json")
 with open(nvidia_version_path, "r") as nvidia_version_file:
     # parse this json file to get the version of the nvidia toolchain
     NVIDIA_TOOLCHAIN_VERSION = json.load(nvidia_version_file)
@@ -754,15 +785,17 @@ download_and_copy(
     url_func=lambda system, arch, version:
     f"https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvdisasm/{system}-{arch}/cuda_nvdisasm-{system}-{arch}-{version}-archive.tar.xz",
 )
-download_and_copy(
-    name="nvcc",
-    src_func=lambda system, arch, version: f"cuda_nvcc-{system}-{arch}-{version}-archive/bin/nvlink{exe_extension}",
-    dst_path="bin/nvlink",
-    variable="TRITON_NVLINK_PATH",
-    version=NVIDIA_TOOLCHAIN_VERSION["nvlink"],
-    url_func=lambda system, arch, version:
-    f"https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvcc/{system}-{arch}/cuda_nvcc-{system}-{arch}-{version}-archive.tar.xz",
-)
+# nvlink is only needed for non-ascend builds (triton-ascend nvidia-toolchain-version.json does not have nvlink)
+if not check_env_flag("TRITON_USE_ASCEND", "OFF"):
+    download_and_copy(
+        name="nvcc",
+        src_func=lambda system, arch, version: f"cuda_nvcc-{system}-{arch}-{version}-archive/bin/nvlink{exe_extension}",
+        dst_path="bin/nvlink",
+        variable="TRITON_NVLINK_PATH",
+        version=NVIDIA_TOOLCHAIN_VERSION["nvlink"],
+        url_func=lambda system, arch, version:
+        f"https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvcc/{system}-{arch}/cuda_nvcc-{system}-{arch}-{version}-archive.tar.xz",
+    )
 download_and_copy(
     name="nvcc",
     src_func=lambda system, arch, version: f"cuda_nvcc-{system}-{arch}-{version}-archive/include",
@@ -799,7 +832,10 @@ download_and_copy(
     url_func=lambda system, arch, version:
     f"https://developer.download.nvidia.com/compute/cuda/redist/cuda_cupti/{system}-{arch}/cuda_cupti-{system}-{arch}-{version}-archive.tar.xz",
 )
-backends = [*BackendInstaller.copy(["nvidia", "amd"]), *BackendInstaller.copy_externals()]
+backends = [
+    *BackendInstaller.copy(["ascend", "nvidia", "amd"]),
+    *BackendInstaller.copy_externals(),
+]
 
 
 def add_link_to_backends(external_only, materialization=False):
@@ -835,7 +871,8 @@ def add_link_to_backends(external_only, materialization=False):
         if backend.language_dir:
             # Link the contents of each backend's `language` directory into
             # `triton.language.extra`.
-            extra_dir = os.path.join(os.path.dirname(__file__), os.pardir, "3rdparty", "triton", "python", "triton",
+            triton_subdir = "triton-ascend" if check_env_flag("TRITON_USE_ASCEND", "OFF") else "triton"
+            extra_dir = os.path.join(os.path.dirname(__file__), os.pardir, "3rdparty", triton_subdir, "python", "triton",
                                      "language", "extra")
             for x in os.listdir(backend.language_dir):
                 src_dir = os.path.join(backend.language_dir, x)
@@ -845,7 +882,8 @@ def add_link_to_backends(external_only, materialization=False):
         if backend.tools_dir:
             # Link the contents of each backend's `tools` directory into
             # `triton.tools.extra`.
-            extra_dir = os.path.join(os.path.dirname(__file__), os.pardir, "3rdparty", "triton", "python", "triton",
+            triton_subdir = "triton-ascend" if check_env_flag("TRITON_USE_ASCEND", "OFF") else "triton"
+            extra_dir = os.path.join(os.path.dirname(__file__), os.pardir, "3rdparty", triton_subdir, "python", "triton",
                                      "tools", "extra")
             for x in os.listdir(backend.tools_dir):
                 src_dir = os.path.join(backend.tools_dir, x)
@@ -854,16 +892,18 @@ def add_link_to_backends(external_only, materialization=False):
 
 
 def add_link_to_proton():
+    triton_subdir = "triton-ascend" if check_env_flag("TRITON_USE_ASCEND", "OFF") else "triton"
     proton_dir = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), os.pardir, "3rdparty", "triton", "third_party", "proton", "proton"))
-    proton_install_dir = os.path.join(os.path.dirname(__file__), os.pardir, "3rdparty", "triton", "python", "triton",
+        os.path.join(os.path.dirname(__file__), os.pardir, "3rdparty", triton_subdir, "third_party", "proton", "proton"))
+    proton_install_dir = os.path.join(os.path.dirname(__file__), os.pardir, "3rdparty", triton_subdir, "python", "triton",
                                       "profiler")
     update_symlink(proton_install_dir, proton_dir)
 
 
 def add_link_to_distributed():
+    triton_subdir = "triton-ascend" if check_env_flag("TRITON_USE_ASCEND", "OFF") else "triton"
     triton_dir = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), os.pardir, "3rdparty", "triton", "python", "triton"))
+        os.path.join(os.path.dirname(__file__), os.pardir, "3rdparty", triton_subdir, "python", "triton"))
     triton_install_dir = os.path.join(os.path.dirname(__file__), "triton")
     update_symlink(triton_install_dir, triton_dir)
 
@@ -954,26 +994,49 @@ def get_extra_packages(extra_name):
     return list(packages)
 
 
+def get_triton_subpackages(base_dir, package_prefix):
+    """Walk a triton subdirectory to enumerate all subpackages dynamically."""
+    packages = []
+    triton_subdir = "triton-ascend" if check_env_flag("TRITON_USE_ASCEND", "OFF") else "triton"
+    full_path = os.path.join(os.path.dirname(__file__), os.pardir, "3rdparty", triton_subdir, "python", base_dir)
+
+    if not os.path.exists(full_path):
+        return packages
+
+    for dir, dirs, files in os.walk(full_path, followlinks=True):
+        # Check if directory contains Python files (has __init__.py or other .py files)
+        if not any(f.endswith(".py") for f in files):
+            continue
+        # Get relative path from the base directory
+        rel_path = os.path.relpath(dir, full_path)
+        if rel_path == ".":
+            # The base directory itself
+            packages.append(package_prefix)
+        else:
+            # Subdirectories
+            package = os.path.join(package_prefix, rel_path).replace(os.sep, "/")
+            packages.append(package)
+
+    return packages
+
+
 def get_packages():
     _packages = [
         "triton",
         "triton/_C",
         "triton/backends",
         "triton/compiler",
-        "triton/experimental",
-        "triton/experimental/gluon",
-        "triton/experimental/gluon/language",
-        "triton/experimental/gluon/nvidia",
-        "triton/experimental/gluon/language/nvidia",
-        "triton/experimental/gluon/language/nvidia/ampere",
-        "triton/experimental/gluon/language/nvidia/hopper",
-        "triton/experimental/gluon/language/nvidia/blackwell",
         "triton/language",
         "triton/language/extra",
         "triton/runtime",
         "triton/tools",
         "triton/tools/extra",
     ]
+    # Dynamically enumerate triton/experimental subpackages
+    _packages += get_triton_subpackages("triton/experimental", "triton/experimental")
+    # Dynamically enumerate triton/extension subpackages (for Ascend)
+    if check_env_flag("TRITON_USE_ASCEND", "OFF"):
+        _packages += get_triton_subpackages("triton/extension", "triton/extension")
     _packages += [f'triton/backends/{backend.name}' for backend in backends]
     _packages += get_extra_packages("language")
     _packages += get_extra_packages("tools")
@@ -992,6 +1055,7 @@ def get_packages():
             "triton_dist/language/extra",
             "triton_dist/language/extra/cuda",
             "triton_dist/language/extra/hip",
+            "triton_dist/language/extra/ascend",
             "triton_dist/mega_triton_kernel",
             "triton_dist/function",
             "triton_dist/function/nvidia",
@@ -1000,6 +1064,7 @@ def get_packages():
             "triton_dist/layers/amd",
             "triton_dist/models",
             "triton_dist/test",
+            "triton_dist/test/ascend",
             "triton_dist/tools",
             "triton_dist/tools/compile",
             "triton_dist/tools/profiler",
@@ -1082,7 +1147,10 @@ def get_git_version_suffix():
 
 
 # set ext_modules
-ext_modules = [CMakeExtension("3rdparty/triton/python/triton", "triton/_C/")]
+if check_env_flag("TRITON_USE_ASCEND", "OFF"):
+    ext_modules = [CMakeExtension("3rdparty/triton-ascend/python/triton", "triton/_C/")]
+else:
+    ext_modules = [CMakeExtension("3rdparty/triton/python/triton", "triton/_C/")]
 
 # Dynamically define supported Python versions and classifiers
 MIN_PYTHON = (3, 9)

--- a/python/setup.py
+++ b/python/setup.py
@@ -84,6 +84,16 @@ def _is_maca_platform():
         return False
 
 
+def _is_ascend_platform():
+    """Checks if 'npu-smi' is available on the system's PATH."""
+    if shutil.which("npu-smi"):
+        print("--- Ascend platform detected (npu-smi found) ---")
+        return True
+    else:
+        print("--- Ascend platform NOT detected ---")
+        return False
+
+
 @dataclass
 class Backend:
     name: str
@@ -103,7 +113,7 @@ class BackendInstaller:
     def prepare(backend_name: str, backend_src_dir: str = None, is_external: bool = False):
         # Initialize submodule if there is one for in-tree backends.
         if not is_external:
-            root_dir = os.path.join(get_base_dir(), "3rdparty", "triton", "third_party")
+            root_dir = os.path.join(get_base_dir(), "3rdparty", triton_subdir, "third_party")
             assert backend_name in os.listdir(
                 root_dir), f"{backend_name} is requested for install but not present in {root_dir}"
 
@@ -115,6 +125,44 @@ class BackendInstaller:
                     pass
                 except FileNotFoundError:
                     pass
+
+            if backend_name == "ascend":
+                TA_dir = Path().resolve().parent / "3rdparty/triton-ascend"
+                npuir_path = TA_dir / "third_party/ascend/AscendNPU-IR"
+                TA_patch = TA_dir / "../triton-ascend.patch"
+                npuir_patch = TA_dir / "../AscendNPU-IR.patch"
+                npuir_dirty = subprocess.call(
+                    [
+                        "git",
+                        "diff-index",
+                        "--quiet",
+                        "HEAD",
+                        "--",
+                    ],
+                    cwd=npuir_path,
+                )
+                TA_dirty = subprocess.call(
+                    [
+                        "git",
+                        "diff-index",
+                        "--quiet",
+                        "HEAD",
+                        "--",
+                    ],
+                    cwd=TA_dir,
+                )
+                if not npuir_dirty:
+                    print("AscendNPU-IR is clean, applying patch...")
+                    try:
+                        subprocess.check_call(["git", "apply", npuir_patch], cwd=npuir_path)
+                    except Exception as e:
+                        raise RuntimeError(f"Failed to apply patch: {e}")
+                if not TA_dirty:
+                    print("AscendNPU-IR is clean, applying patch...")
+                    try:
+                        subprocess.check_call(["git", "apply", TA_patch], cwd=TA_dir)
+                    except Exception as e:
+                        raise RuntimeError(f"Failed to apply patch: {e}")
 
             backend_src_dir = os.path.join(root_dir, backend_name)
 
@@ -132,7 +180,7 @@ class BackendInstaller:
         for file in ["compiler.py", "driver.py"]:
             assert os.path.exists(os.path.join(backend_path, file)), f"${file} does not exist in ${backend_path}"
 
-        install_dir = os.path.join(os.path.dirname(__file__), os.pardir, "3rdparty", "triton", "python", "triton",
+        install_dir = os.path.join(os.path.dirname(__file__), os.pardir, "3rdparty", triton_subdir, "python", "triton",
                                    "backends", backend_name)
 
         dist_backend_path = None
@@ -166,6 +214,9 @@ class BackendInstaller:
 # Taken from https://github.com/pytorch/pytorch/blob/master/tools/setup_helpers/env.py
 def check_env_flag(name: str, default: str = "") -> bool:
     return os.getenv(name, default).upper() in ["ON", "1", "YES", "TRUE", "Y"]
+
+
+triton_subdir = "triton-ascend" if _is_ascend_platform() and check_env_flag("TRITON_USE_ASCEND", "OFF") else "triton"
 
 
 def get_build_type():
@@ -275,7 +326,7 @@ def get_llvm_package_info():
         return Package("llvm", "LLVM-C.lib", "", "LLVM_INCLUDE_DIRS", "LLVM_LIBRARY_DIR", "LLVM_SYSPATH")
     # use_assert_enabled_llvm = check_env_flag("TRITON_USE_ASSERT_ENABLED_LLVM", "False")
     # release_suffix = "assert" if use_assert_enabled_llvm else "release"
-    llvm_hash_path = os.path.join(get_base_dir(), "3rdparty", "triton", "cmake", "llvm-hash.txt")
+    llvm_hash_path = os.path.join(get_base_dir(), "3rdparty", triton_subdir, "cmake", "llvm-hash.txt")
     with open(llvm_hash_path, "r") as llvm_hash_file:
         rev = llvm_hash_file.read(8)
     name = f"llvm-{rev}-{system_suffix}"
@@ -387,7 +438,7 @@ def download_and_copy(name, src_func, dst_path, variable, version, url_func):
     url = url_func(supported[system], arch, version)
     src_path = src_func(supported[system], arch, version)
     tmp_path = os.path.join(triton_cache_path, "nvidia", name)  # path to cache the download
-    dst_path = os.path.join(base_dir, os.pardir, "3rdparty", "triton", "third_party", "nvidia", "backend",
+    dst_path = os.path.join(base_dir, os.pardir, "3rdparty", triton_subdir, "third_party", "nvidia", "backend",
                             dst_path)  # final binary path
     src_path = os.path.join(tmp_path, src_path)
     download = not os.path.exists(src_path)
@@ -600,13 +651,13 @@ class CMakeBuild(build_ext):
         cmake_args += self.get_pybind11_cmake_args()
         cupti_include_dir = get_env_with_keys(["TRITON_CUPTI_INCLUDE_PATH"])
         if cupti_include_dir == "":
-            cupti_include_dir = os.path.join(get_base_dir(), "3rdparty", "triton", "third_party", "nvidia", "backend",
-                                             "include")
+            cupti_include_dir = os.path.join(get_base_dir(), "3rdparty", triton_subdir, "third_party", "nvidia",
+                                             "backend", "include")
         cmake_args += ["-DCUPTI_INCLUDE_DIR=" + cupti_include_dir]
         roctracer_include_dir = get_env_with_keys(["TRITON_ROCTRACER_INCLUDE_PATH"])
         if roctracer_include_dir == "":
-            roctracer_include_dir = os.path.join(get_base_dir(), "3rdparty", "triton", "third_party", "amd", "backend",
-                                                 "include")
+            roctracer_include_dir = os.path.join(get_base_dir(), "3rdparty", triton_subdir, "third_party", "amd",
+                                                 "backend", "include")
         cmake_args += ["-DROCTRACER_INCLUDE_DIR=" + roctracer_include_dir]
         return cmake_args
 
@@ -691,6 +742,7 @@ class CMakeBuild(build_ext):
             "TRITON_BUILD_DISTRIBUTED",
             "TRITON_BUILD_WITH_CCACHE",
             "TRITON_PARALLEL_LINK_JOBS",
+            "TRITON_USE_ASCEND",
         ]
         cmake_args += [f"-D{option}={os.getenv(option)}" for option in passthrough_args if option in os.environ]
 
@@ -708,6 +760,10 @@ class CMakeBuild(build_ext):
         if cmake_args_append is not None:
             cmake_args += shlex.split(cmake_args_append)
 
+        # LLVM version compatibility for Ascend
+        if _is_ascend_platform() and check_env_flag("TRITON_USE_ASCEND", "OFF"):
+            cmake_args += ["-DLLVM_MAJOR_VERSION_22_COMPATIBLE=ON"]
+
         # USE MACA
         if _is_maca_platform() and check_env_flag("TRITON_USE_MACA", "OFF"):  # Default OFF
             cmake_args += ["-DTRITON_USE_MACA=ON"]
@@ -720,8 +776,30 @@ class CMakeBuild(build_ext):
         subprocess.check_call(["cmake", "--build", "."] + build_args, cwd=cmake_dir)
         subprocess.check_call(["cmake", "--build", ".", "--target", "mlir-doc"], cwd=cmake_dir)
 
+        if _is_ascend_platform() and check_env_flag("TRITON_USE_ASCEND", "OFF"):
+            # Copy triton-mlir-opt tool to extdir for runtime use
+            # This tool is needed for converting MLIR to Bytecode
+            triton_mlir_opt_src = os.path.join(cmake_dir, "3rdparty", "triton-ascend", "bin", "triton-mlir-opt")
+            if os.path.exists(triton_mlir_opt_src):
+                triton_mlir_opt_dst = os.path.join(extdir, "triton-mlir-opt")
+                shutil.copy2(triton_mlir_opt_src, triton_mlir_opt_dst)
+                # Make it executable (Unix-like systems)
+                if platform.system() != "Windows":
+                    os.chmod(triton_mlir_opt_dst, 0o755)
+                    # Strip debug symbols to reduce binary size (can reduce size by ~80%)
+                    try:
+                        subprocess.check_call(["strip", "--strip-all", triton_mlir_opt_dst])
+                        print("Stripped triton-mlir-opt to reduce size")
+                    except (subprocess.CalledProcessError, FileNotFoundError):
+                        # strip command not available or failed, continue without stripping
+                        pass
+                print(f"Copied triton-mlir-opt to {triton_mlir_opt_dst}")
 
-nvidia_version_path = os.path.join(get_base_dir(), "3rdparty", "triton", "cmake", "nvidia-toolchain-version.json")
+
+nvidia_version_path = os.path.join(
+    get_base_dir(), "3rdparty",
+    triton_subdir, "cmake",
+    "nvidia-toolchain-version.json")
 with open(nvidia_version_path, "r") as nvidia_version_file:
     # parse this json file to get the version of the nvidia toolchain
     NVIDIA_TOOLCHAIN_VERSION = json.load(nvidia_version_file)
@@ -756,15 +834,17 @@ download_and_copy(
     url_func=lambda system, arch, version:
     f"https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvdisasm/{system}-{arch}/cuda_nvdisasm-{system}-{arch}-{version}-archive.tar.xz",
 )
-download_and_copy(
-    name="nvcc",
-    src_func=lambda system, arch, version: f"cuda_nvcc-{system}-{arch}-{version}-archive/bin/nvlink{exe_extension}",
-    dst_path="bin/nvlink",
-    variable="TRITON_NVLINK_PATH",
-    version=NVIDIA_TOOLCHAIN_VERSION["nvlink"],
-    url_func=lambda system, arch, version:
-    f"https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvcc/{system}-{arch}/cuda_nvcc-{system}-{arch}-{version}-archive.tar.xz",
-)
+# nvlink is only needed for non-ascend builds (triton-ascend nvidia-toolchain-version.json does not have nvlink)
+if not (_is_ascend_platform() and check_env_flag("TRITON_USE_ASCEND", "OFF")):
+    download_and_copy(
+        name="nvcc",
+        src_func=lambda system, arch, version: f"cuda_nvcc-{system}-{arch}-{version}-archive/bin/nvlink{exe_extension}",
+        dst_path="bin/nvlink",
+        variable="TRITON_NVLINK_PATH",
+        version=NVIDIA_TOOLCHAIN_VERSION["nvlink"],
+        url_func=lambda system, arch, version:
+        f"https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvcc/{system}-{arch}/cuda_nvcc-{system}-{arch}-{version}-archive.tar.xz",
+    )
 download_and_copy(
     name="nvcc",
     src_func=lambda system, arch, version: f"cuda_nvcc-{system}-{arch}-{version}-archive/include",
@@ -804,6 +884,8 @@ download_and_copy(
 _backend_list = ["nvidia", "amd"]
 if _is_maca_platform() and check_env_flag("TRITON_USE_MACA", "OFF"):
     _backend_list.append("metax")
+if _is_ascend_platform() and check_env_flag("TRITON_USE_ASCEND", "OFF"):
+    _backend_list.append("ascend")
 backends = [*BackendInstaller.copy(_backend_list), *BackendInstaller.copy_externals()]
 
 
@@ -840,8 +922,8 @@ def add_link_to_backends(external_only, materialization=False):
         if backend.language_dir:
             # Link the contents of each backend's `language` directory into
             # `triton.language.extra`.
-            extra_dir = os.path.join(os.path.dirname(__file__), os.pardir, "3rdparty", "triton", "python", "triton",
-                                     "language", "extra")
+            extra_dir = os.path.join(os.path.dirname(__file__), os.pardir, "3rdparty", triton_subdir, "python",
+                                     "triton", "language", "extra")
             for x in os.listdir(backend.language_dir):
                 src_dir = os.path.join(backend.language_dir, x)
                 install_dir = os.path.join(extra_dir, x)
@@ -850,8 +932,8 @@ def add_link_to_backends(external_only, materialization=False):
         if backend.tools_dir:
             # Link the contents of each backend's `tools` directory into
             # `triton.tools.extra`.
-            extra_dir = os.path.join(os.path.dirname(__file__), os.pardir, "3rdparty", "triton", "python", "triton",
-                                     "tools", "extra")
+            extra_dir = os.path.join(os.path.dirname(__file__), os.pardir, "3rdparty", triton_subdir, "python",
+                                     "triton", "tools", "extra")
             for x in os.listdir(backend.tools_dir):
                 src_dir = os.path.join(backend.tools_dir, x)
                 install_dir = os.path.join(extra_dir, x)
@@ -860,15 +942,16 @@ def add_link_to_backends(external_only, materialization=False):
 
 def add_link_to_proton():
     proton_dir = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), os.pardir, "3rdparty", "triton", "third_party", "proton", "proton"))
-    proton_install_dir = os.path.join(os.path.dirname(__file__), os.pardir, "3rdparty", "triton", "python", "triton",
-                                      "profiler")
+        os.path.join(os.path.dirname(__file__), os.pardir, "3rdparty", triton_subdir, "third_party", "proton",
+                     "proton"))
+    proton_install_dir = os.path.join(os.path.dirname(__file__), os.pardir, "3rdparty", triton_subdir, "python",
+                                      "triton", "profiler")
     update_symlink(proton_install_dir, proton_dir)
 
 
 def add_link_to_distributed():
     triton_dir = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), os.pardir, "3rdparty", "triton", "python", "triton"))
+        os.path.join(os.path.dirname(__file__), os.pardir, "3rdparty", triton_subdir, "python", "triton"))
     triton_install_dir = os.path.join(os.path.dirname(__file__), "triton")
     update_symlink(triton_install_dir, triton_dir)
     if _is_maca_platform() and check_env_flag("TRITON_USE_MACA", "OFF"):
@@ -924,7 +1007,7 @@ class plugin_egg_info(egg_info):
 class plugin_install(install):
 
     def run(self):
-        add_links(external_only=True)
+        add_links(external_only=False)
         super().run()
 
 
@@ -973,26 +1056,48 @@ def get_extra_packages(extra_name):
     return list(packages)
 
 
+def get_triton_subpackages(base_dir, package_prefix):
+    """Walk a triton subdirectory to enumerate all subpackages dynamically."""
+    packages = []
+    full_path = os.path.join(os.path.dirname(__file__), os.pardir, "3rdparty", triton_subdir, "python", base_dir)
+
+    if not os.path.exists(full_path):
+        return packages
+
+    for dir, dirs, files in os.walk(full_path, followlinks=True):
+        # Check if directory contains Python files (has __init__.py or other .py files)
+        if not any(f.endswith(".py") for f in files):
+            continue
+        # Get relative path from the base directory
+        rel_path = os.path.relpath(dir, full_path)
+        if rel_path == ".":
+            # The base directory itself
+            packages.append(package_prefix)
+        else:
+            # Subdirectories
+            package = os.path.join(package_prefix, rel_path).replace(os.sep, "/")
+            packages.append(package)
+
+    return packages
+
+
 def get_packages():
     _packages = [
         "triton",
         "triton/_C",
         "triton/backends",
         "triton/compiler",
-        "triton/experimental",
-        "triton/experimental/gluon",
-        "triton/experimental/gluon/language",
-        "triton/experimental/gluon/nvidia",
-        "triton/experimental/gluon/language/nvidia",
-        "triton/experimental/gluon/language/nvidia/ampere",
-        "triton/experimental/gluon/language/nvidia/hopper",
-        "triton/experimental/gluon/language/nvidia/blackwell",
         "triton/language",
         "triton/language/extra",
         "triton/runtime",
         "triton/tools",
         "triton/tools/extra",
     ]
+    # Dynamically enumerate triton/experimental subpackages
+    _packages += get_triton_subpackages("triton/experimental", "triton/experimental")
+    # Dynamically enumerate triton/extension subpackages (for Ascend)
+    if _is_ascend_platform() and check_env_flag("TRITON_USE_ASCEND", "OFF"):
+        _packages += get_triton_subpackages("triton/extension", "triton/extension")
     _packages += [f'triton/backends/{backend.name}' for backend in backends]
     _packages += get_extra_packages("language")
     _packages += get_extra_packages("tools")
@@ -1011,6 +1116,7 @@ def get_packages():
             "triton_dist/language/extra",
             "triton_dist/language/extra/cuda",
             "triton_dist/language/extra/hip",
+            "triton_dist/language/extra/ascend",
             "triton_dist/mega_triton_kernel",
             "triton_dist/function",
             "triton_dist/function/nvidia",
@@ -1019,6 +1125,7 @@ def get_packages():
             "triton_dist/layers/amd",
             "triton_dist/models",
             "triton_dist/test",
+            "triton_dist/test/ascend",
             "triton_dist/tools",
             "triton_dist/tools/compile",
             "triton_dist/tools/profiler",
@@ -1103,7 +1210,10 @@ def get_git_version_suffix():
 
 
 # set ext_modules
-ext_modules = [CMakeExtension("3rdparty/triton/python/triton", "triton/_C/")]
+if _is_ascend_platform() and check_env_flag("TRITON_USE_ASCEND", "OFF"):
+    ext_modules = [CMakeExtension("3rdparty/triton-ascend/python/triton", "triton/_C/")]
+else:
+    ext_modules = [CMakeExtension("3rdparty/triton/python/triton", "triton/_C/")]
 
 # Dynamically define supported Python versions and classifiers
 MIN_PYTHON = (3, 9)

--- a/python/src/ascend_passes.cc
+++ b/python/src/ascend_passes.cc
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "TritonDistributed/Conversion/TritonDistributedToHIVM/Passes.h"
+#include "mlir/Conversion/Passes.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/Passes.h"
+#include "python/src/passes.h"
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+namespace py = pybind11;
+
+void init_triton_distributed_passes_ttgpuir_for_ascend(py::module &&m) {
+  using namespace mlir::triton::ASCEND;
+  ADD_PASS_WRAPPER_0("add_convert_triton_distributed_to_hivm",
+                     createConvertTritonDistributedToHIVMPass);
+}
+
+void init_triton_distributed_ascend_passes(py::module &&m) {
+  init_triton_distributed_passes_ttgpuir_for_ascend(m.def_submodule("ttgpuir"));
+}

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -37,8 +37,15 @@
 #include "llvm/Support/SourceMgr.h"
 
 #include "TritonDistributed/Dialect/Distributed/IR/Dialect.h"
+#ifndef TRITON_USE_ASCEND
 #include "TritonDistributed/Dialect/SIMT/IR/Dialect.h"
+#endif
+
+#ifdef TRITON_USE_ASCEND
+#include "third_party/proton/Dialect/include/Dialect/Proton/IR/Dialect.h"
+#else
 #include "third_party/proton/dialect/include/Dialect/Proton/IR/Dialect.h"
+#endif
 
 namespace {
 
@@ -135,14 +142,16 @@ void init_triton_distributed_ir(py::module &&m) {
 
   m.def("load_dialects", [](MLIRContext &context) {
     DialectRegistry registry;
-    registry
-        .insert<TritonDialect, ::mlir::triton::gpu::TritonGPUDialect,
-                math::MathDialect, arith::ArithDialect, scf::SCFDialect,
-                tensor::TensorDialect, ::mlir::gpu::GPUDialect,
-                cf::ControlFlowDialect, ::mlir::triton::proton::ProtonDialect,
-                ::mlir::triton::distributed::DistributedDialect,
-                ::mlir::triton::simt::SIMTDialect, LLVM::LLVMDialect,
-                mlir::ub::UBDialect>();
+    registry.insert<TritonDialect, ::mlir::triton::gpu::TritonGPUDialect,
+                    math::MathDialect, arith::ArithDialect, scf::SCFDialect,
+                    tensor::TensorDialect, ::mlir::gpu::GPUDialect,
+                    cf::ControlFlowDialect,
+                    ::mlir::triton::proton::ProtonDialect,
+                    ::mlir::triton::distributed::DistributedDialect,
+#ifndef TRITON_USE_ASCEND
+                    ::mlir::triton::simt::SIMTDialect,
+#endif
+                    LLVM::LLVMDialect, mlir::ub::UBDialect>();
     mlir::LLVM::registerInlinerInterface(registry);
     registerBuiltinDialectTranslation(registry);
     registerLLVMDialectTranslation(registry);
@@ -151,7 +160,8 @@ void init_triton_distributed_ir(py::module &&m) {
     context.loadAllAvailableDialects();
   });
 
-  // simt ops
+// simt ops
+#ifndef TRITON_USE_ASCEND
   py::class_<triton::simt::BlockYieldOp, OpState>(m, "BlockYieldOp",
                                                   py::module_local());
   py::class_<triton::simt::SIMTExecRegionOp, OpState>(m, "SIMTExecRegionOp",
@@ -162,7 +172,7 @@ void init_triton_distributed_ir(py::module &&m) {
             return &self.getDefaultRegion().front();
           },
           ret::reference);
-
+#endif
   // DistributedOpBuilder inherit the original triton builder and add the
   // support of TritonDitributed. In this way, we can directly use this new
   // builder without maintaining two builders on the Python side. Because the
@@ -170,7 +180,8 @@ void init_triton_distributed_ir(py::module &&m) {
   py::class_<DistributedOpBuilder, TritonOpBuilder>(
       m, "DistributedOpBuilder", py::module_local(), py::dynamic_attr())
       .def(py::init<MLIRContext *>())
-      // SIMT ops
+// SIMT ops
+#ifndef TRITON_USE_ASCEND
       .def("create_get_thread_id",
            [](TritonOpBuilder &self) -> Value {
              // triton only use 1D thread block
@@ -247,7 +258,7 @@ void init_triton_distributed_ir(py::module &&m) {
                                                              width, shflMode);
              return shflOp.getShuffleResult();
            })
-
+#endif
       // Distributed Ops
       .def("create_distributed_wait",
            [](TritonOpBuilder &self, Value &barrierPtrs, Value &numBarriers,

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -37,8 +37,11 @@
 #include "llvm/Support/SourceMgr.h"
 
 #include "TritonDistributed/Dialect/Distributed/IR/Dialect.h"
+#ifndef TRITON_USE_ASCEND
 #include "TritonDistributed/Dialect/SIMT/IR/Dialect.h"
-#ifdef USE_MACA
+#endif
+
+#if defined(USE_MACA) || defined(TRITON_USE_ASCEND)
 // for directory compatible
 #include "third_party/proton/Dialect/include/Dialect/Proton/IR/Dialect.h"
 #else
@@ -146,8 +149,10 @@ void init_triton_distributed_ir(py::module &&m) {
                 tensor::TensorDialect, ::mlir::gpu::GPUDialect,
                 cf::ControlFlowDialect, ::mlir::triton::proton::ProtonDialect,
                 ::mlir::triton::distributed::DistributedDialect,
-                ::mlir::triton::simt::SIMTDialect, LLVM::LLVMDialect,
-                mlir::ub::UBDialect>();
+#ifndef TRITON_USE_ASCEND
+                ::mlir::triton::simt::SIMTDialect,
+#endif
+                LLVM::LLVMDialect, mlir::ub::UBDialect>();
     mlir::LLVM::registerInlinerInterface(registry);
     registerBuiltinDialectTranslation(registry);
     registerLLVMDialectTranslation(registry);
@@ -156,7 +161,8 @@ void init_triton_distributed_ir(py::module &&m) {
     context.loadAllAvailableDialects();
   });
 
-  // simt ops
+// simt ops
+#ifndef TRITON_USE_ASCEND
   py::class_<triton::simt::BlockYieldOp, OpState>(m, "BlockYieldOp",
                                                   py::module_local());
   py::class_<triton::simt::SIMTExecRegionOp, OpState>(m, "SIMTExecRegionOp",
@@ -167,7 +173,7 @@ void init_triton_distributed_ir(py::module &&m) {
             return &self.getDefaultRegion().front();
           },
           ret::reference);
-
+#endif
   // DistributedOpBuilder inherit the original triton builder and add the
   // support of TritonDitributed. In this way, we can directly use this new
   // builder without maintaining two builders on the Python side. Because the
@@ -175,7 +181,8 @@ void init_triton_distributed_ir(py::module &&m) {
   py::class_<DistributedOpBuilder, TritonOpBuilder>(
       m, "DistributedOpBuilder", py::module_local(), py::dynamic_attr())
       .def(py::init<MLIRContext *>())
-      // SIMT ops
+// SIMT ops
+#ifndef TRITON_USE_ASCEND
       .def("create_get_thread_id",
            [](TritonOpBuilder &self) -> Value {
              // triton only use 1D thread block
@@ -252,7 +259,7 @@ void init_triton_distributed_ir(py::module &&m) {
                                                              width, shflMode);
              return shflOp.getShuffleResult();
            })
-
+#endif
       // Distributed Ops
       .def("create_distributed_wait",
            [](TritonOpBuilder &self, Value &barrierPtrs, Value &numBarriers,

--- a/python/src/triton_distributed.cc
+++ b/python/src/triton_distributed.cc
@@ -30,10 +30,19 @@
 
 namespace py = pybind11;
 
+#ifndef TRITON_USE_ASCEND
 void init_triton_distributed_passes(pybind11::module &&m);
+#else
+void init_triton_distributed_ascend_passes(pybind11::module &&m);
+#endif
+
 void init_triton_distributed_ir(py::module &&m);
 
 void init_triton_distributed(py::module &&m) {
+#ifndef TRITON_USE_ASCEND
   init_triton_distributed_passes(m.def_submodule("passes"));
+#else
+  init_triton_distributed_ascend_passes(m.def_submodule("ascend_passes"));
+#endif
   init_triton_distributed_ir(m.def_submodule("ir"));
 }

--- a/python/triton_dist/jit.py
+++ b/python/triton_dist/jit.py
@@ -35,7 +35,7 @@ import triton
 from triton.runtime.errors import PTXASError
 from triton.runtime.jit import JITFunction, KernelInterface
 from triton import knobs
-from triton_dist.utils import is_cuda, is_hip, is_maca, HIP_CHECK
+from triton_dist.utils import is_ascend, is_cuda, is_hip, is_maca, HIP_CHECK
 
 T = TypeVar("T")
 
@@ -95,6 +95,8 @@ def shmem_kernel_module_init_hook(*args, **kwargs) -> None:
         if "mxshmem" in kernel.asm['ttir']:
             import pymxshmem
             pymxshmem.mxshmemx_mcmodule_init(kernel_module)
+    elif is_ascend():
+        pass
     else:
         raise ValueError("Unsupported device type for shmem kernel module init hook.")
 

--- a/python/triton_dist/jit.py
+++ b/python/triton_dist/jit.py
@@ -35,7 +35,7 @@ import triton
 from triton.runtime.errors import PTXASError
 from triton.runtime.jit import JITFunction, KernelInterface
 from triton import knobs
-from triton_dist.utils import is_cuda, is_hip, is_maca, HIP_CHECK
+from triton_dist.utils import is_ascend, is_cuda, is_hip, is_maca, HIP_CHECK
 
 T = TypeVar("T")
 
@@ -95,6 +95,8 @@ def shmem_kernel_module_init_hook(*args, **kwargs) -> None:
         if "mxshmem" in kernel.asm['ttir']:
             import triton.pymxshmem as pymxshmem
             pymxshmem.mxshmemx_mcmodule_init(kernel_module)
+    elif is_ascend():
+        pass
     else:
         raise ValueError("Unsupported device type for shmem kernel module init hook.")
 

--- a/python/triton_dist/language/extra/ascend/__init__.py
+++ b/python/triton_dist/language/extra/ascend/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+from . import language_extra, libaclshmem_device
+
+__all__ = ["language_extra", "libaclshmem_device"]

--- a/python/triton_dist/language/extra/ascend/algorithm.py
+++ b/python/triton_dist/language/extra/ascend/algorithm.py
@@ -1,0 +1,67 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def dist_swizzle2d_Nz(
+    iter_id,
+    rank_size,
+    data_row_shape,
+    data_col_shape,
+    tile_row_shape,
+    tile_col_shape,
+    comm_npu_split=1,
+):
+    """communication swizzle Nz"""
+    data_row_loop_num = tl.cdiv(data_row_shape, tile_row_shape)
+    data_col_loop_num = tl.cdiv(data_col_shape, tile_col_shape)
+    data_loop_num = data_row_loop_num * data_col_loop_num
+    rank_stride = rank_size // comm_npu_split
+    swizzle_offset = comm_npu_split
+    rank_loop_num = tl.cdiv(rank_size, swizzle_offset)
+    rank_tile_idx = iter_id // (swizzle_offset * data_loop_num)
+    data_rank_tile_idx = iter_id % (swizzle_offset * data_loop_num)
+    rank_tile_size = swizzle_offset
+    if rank_tile_idx == rank_loop_num - 1:
+        rank_tile_size = rank_size - swizzle_offset * rank_tile_idx
+    data_tile_idx = data_rank_tile_idx // rank_tile_size
+    rank_idx = rank_tile_idx * swizzle_offset + data_rank_tile_idx % rank_tile_size
+    rank_idx = (rank_idx * rank_stride) % rank_stride + (
+        rank_idx * rank_stride
+    ) // rank_size
+    rank_idx = (rank_idx + data_tile_idx) % rank_size
+    data_row_idx = data_tile_idx // data_col_loop_num
+    data_col_idx = data_tile_idx % data_col_loop_num
+    comm_row_size = tl.minimum(
+        data_row_shape - data_row_idx * tile_row_shape, tile_row_shape
+    )
+    comm_col_size = tl.minimum(
+        data_col_shape - data_col_idx * tile_col_shape, tile_col_shape
+    )
+    return data_row_idx, data_col_idx, rank_idx, comm_row_size, comm_col_size
+
+
+@triton.jit
+def gemm_swizzle2d_Nz(
+    iter_id,
+    data_row_shape,
+    data_col_shape,
+    tile_row_shape,
+    tile_col_shape,
+    swizzle_offset=7,
+):
+    """gemm swizzle Nz"""
+    data_row_loop_num = tl.cdiv(data_row_shape, tile_row_shape)
+    data_col_loop_num = tl.cdiv(data_col_shape, tile_col_shape)
+    col_loop_num = tl.cdiv(data_col_loop_num, swizzle_offset)
+    n_tile_idx = iter_id // (swizzle_offset * data_row_loop_num)
+    m_n_tile_idx = iter_id % (swizzle_offset * data_row_loop_num)
+    n_tile_size = swizzle_offset
+    if n_tile_idx == col_loop_num - 1:
+        n_tile_size = data_col_loop_num - swizzle_offset * n_tile_idx
+    data_row_idx = m_n_tile_idx // n_tile_size
+    data_col_idx = n_tile_idx * swizzle_offset + m_n_tile_idx % n_tile_size
+    if n_tile_idx % 2 == 1:
+        data_row_idx = data_row_loop_num - data_row_idx - 1
+    return data_row_idx, data_col_idx

--- a/python/triton_dist/language/extra/ascend/algorithm.py
+++ b/python/triton_dist/language/extra/ascend/algorithm.py
@@ -1,0 +1,61 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def dist_swizzle2d_Nz(
+    iter_id,
+    rank_size,
+    data_row_shape,
+    data_col_shape,
+    tile_row_shape,
+    tile_col_shape,
+    comm_npu_split=1,
+):
+    """communication swizzle Nz"""
+    data_row_loop_num = tl.cdiv(data_row_shape, tile_row_shape)
+    data_col_loop_num = tl.cdiv(data_col_shape, tile_col_shape)
+    data_loop_num = data_row_loop_num * data_col_loop_num
+    rank_stride = rank_size // comm_npu_split
+    swizzle_offset = comm_npu_split
+    rank_loop_num = tl.cdiv(rank_size, swizzle_offset)
+    rank_tile_idx = iter_id // (swizzle_offset * data_loop_num)
+    data_rank_tile_idx = iter_id % (swizzle_offset * data_loop_num)
+    rank_tile_size = swizzle_offset
+    if rank_tile_idx == rank_loop_num - 1:
+        rank_tile_size = rank_size - swizzle_offset * rank_tile_idx
+    data_tile_idx = data_rank_tile_idx // rank_tile_size
+    rank_idx = rank_tile_idx * swizzle_offset + data_rank_tile_idx % rank_tile_size
+    rank_idx = (rank_idx * rank_stride) % rank_stride + (rank_idx * rank_stride) // rank_size
+    rank_idx = (rank_idx + data_tile_idx) % rank_size
+    data_row_idx = data_tile_idx // data_col_loop_num
+    data_col_idx = data_tile_idx % data_col_loop_num
+    comm_row_size = tl.minimum(data_row_shape - data_row_idx * tile_row_shape, tile_row_shape)
+    comm_col_size = tl.minimum(data_col_shape - data_col_idx * tile_col_shape, tile_col_shape)
+    return data_row_idx, data_col_idx, rank_idx, comm_row_size, comm_col_size
+
+
+@triton.jit
+def gemm_swizzle2d_Nz(
+    iter_id,
+    data_row_shape,
+    data_col_shape,
+    tile_row_shape,
+    tile_col_shape,
+    swizzle_offset=7,
+):
+    """gemm swizzle Nz"""
+    data_row_loop_num = tl.cdiv(data_row_shape, tile_row_shape)
+    data_col_loop_num = tl.cdiv(data_col_shape, tile_col_shape)
+    col_loop_num = tl.cdiv(data_col_loop_num, swizzle_offset)
+    n_tile_idx = iter_id // (swizzle_offset * data_row_loop_num)
+    m_n_tile_idx = iter_id % (swizzle_offset * data_row_loop_num)
+    n_tile_size = swizzle_offset
+    if n_tile_idx == col_loop_num - 1:
+        n_tile_size = data_col_loop_num - swizzle_offset * n_tile_idx
+    data_row_idx = m_n_tile_idx // n_tile_size
+    data_col_idx = n_tile_idx * swizzle_offset + m_n_tile_idx % n_tile_size
+    if n_tile_idx % 2 == 1:
+        data_row_idx = data_row_loop_num - data_row_idx - 1
+    return data_row_idx, data_col_idx

--- a/python/triton_dist/language/extra/ascend/language_extra.py
+++ b/python/triton_dist/language/extra/ascend/language_extra.py
@@ -1,0 +1,1 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.

--- a/python/triton_dist/language/extra/ascend/libaclshmem_device.py
+++ b/python/triton_dist/language/extra/ascend/libaclshmem_device.py
@@ -1,0 +1,109 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+from triton.language import core
+import triton.language as tl
+from triton_dist.language.core import extern_call
+
+pi_u64_t = tl.core.pointer_type(tl.core.dtype("uint64"))
+
+void_ptr = core.pointer_type(core.void)
+
+
+@core.extern
+def my_pe(_semantic=None):
+    return extern_call(
+        "libshmem_device",
+        "",
+        [],
+        {
+            (): ("aclshmem_my_pe", core.dtype("int32")),
+        },
+        is_pure=True,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def n_pes(_semantic=None):
+    return extern_call(
+        "libshmem_device",
+        "",
+        [],
+        {
+            (): ("aclshmem_n_pes", core.dtype("int32")),
+        },
+        is_pure=True,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def int_p(dest, value, pe, _semantic=None):
+    # force have a return value, even not used.
+    return extern_call(
+        "libshmem_device",
+        "",
+        [dest, value, pe],
+        {
+            (
+                core.pointer_type(core.dtype("int32")),
+                core.dtype("int32"),
+                core.dtype("int32"),
+            ): (
+                "aclshmem_int32_p",
+                (),
+            ),  # void return type
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def remote_ptr(local_ptr, pe, _semantic=None):
+    return extern_call(
+        "libshmem_device",
+        "",
+        [local_ptr, pe],
+        {
+            (core.pointer_type(core.dtype(core_dtype)), core.dtype(pe_dtype)): (
+                "aclshmem_ptr",
+                core.pointer_type(core.dtype(core_dtype)),  # of the same dtype
+            )
+            for core_dtype in core.dtype.SINT_TYPES
+            + core.dtype.UINT_TYPES
+            + core.dtype.FP_TYPES
+            + core.dtype.OTHER_TYPES
+            for pe_dtype in ["int32", "uint32"]
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def barrier_all(_semantic=None):
+    return extern_call(
+        "libshmem_device",
+        "",
+        [],
+        {
+            (): ("aclshmem_barrier_all", ()),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def barrier_all_vec(_semantic=None):
+    return extern_call(
+        "libshmem_device",
+        "",
+        [],
+        {
+            (): ("aclshmemx_barrier_all_vec", ()),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )

--- a/python/triton_dist/language/extra/ascend/libaclshmem_device.py
+++ b/python/triton_dist/language/extra/ascend/libaclshmem_device.py
@@ -1,0 +1,102 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+from triton.language import core
+import triton.language as tl
+from triton_dist.language.core import extern_call
+
+pi_u64_t = tl.core.pointer_type(tl.core.dtype("uint64"))
+
+void_ptr = core.pointer_type(core.void)
+
+
+@core.extern
+def my_pe(_semantic=None):
+    return extern_call(
+        "libshmem_device",
+        "",
+        [],
+        {
+            (): ("aclshmem_my_pe", core.dtype("int32")),
+        },
+        is_pure=True,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def n_pes(_semantic=None):
+    return extern_call(
+        "libshmem_device",
+        "",
+        [],
+        {
+            (): ("aclshmem_n_pes", core.dtype("int32")),
+        },
+        is_pure=True,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def int_p(dest, value, pe, _semantic=None):
+    # force have a return value, even not used.
+    return extern_call(
+        "libshmem_device",
+        "",
+        [dest, value, pe],
+        {(
+            core.pointer_type(core.dtype("int32")),
+            core.dtype("int32"),
+            core.dtype("int32"),
+        ): (
+             "aclshmem_int32_p",
+             (),
+         ),  # void return type
+         },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def remote_ptr(local_ptr, pe, _semantic=None):
+    return extern_call(
+        "libshmem_device",
+        "",
+        [local_ptr, pe],
+        {(core.pointer_type(core.dtype(core_dtype)), core.dtype(pe_dtype)): (
+             "aclshmem_ptr", core.pointer_type(core.dtype(core_dtype)),  # of the same dtype
+         )
+         for core_dtype in core.dtype.SINT_TYPES + core.dtype.UINT_TYPES + core.dtype.FP_TYPES + core.dtype.OTHER_TYPES
+         for pe_dtype in ["int32", "uint32"]},
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def barrier_all(_semantic=None):
+    return extern_call(
+        "libshmem_device",
+        "",
+        [],
+        {
+            (): ("aclshmem_barrier_all", ()),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def barrier_all_vec(_semantic=None):
+    return extern_call(
+        "libshmem_device",
+        "",
+        [],
+        {
+            (): ("aclshmemx_barrier_all_vec", ()),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )

--- a/python/triton_dist/language/extra/language_extra.py
+++ b/python/triton_dist/language/extra/language_extra.py
@@ -22,19 +22,26 @@
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 ################################################################################
-import triton_dist.language.extra.cuda.language_extra as cuda_language_extra
-import triton_dist.language.extra.hip.language_extra as hip_language_extra
-import triton_dist.language.extra.maca.language_extra as maca_language_extra
-from triton_dist.utils import is_cuda, is_hip, is_maca
+from triton_dist.utils import is_ascend, is_cuda, is_hip, is_maca
 from triton_dist.language import vector
 from triton.language import core
 from .utils import ModuleProxy
 
-_extra_module = ModuleProxy([
-    (is_cuda, cuda_language_extra),
-    (is_hip, hip_language_extra),
-    (is_maca, maca_language_extra),
-])
+proxy_list = []
+if is_cuda():
+    import triton_dist.language.extra.cuda.language_extra as cuda_language_extra
+    proxy_list.append((is_cuda, cuda_language_extra))
+if is_hip():
+    import triton_dist.language.extra.hip.language_extra as hip_language_extra
+    proxy_list.append((is_hip, hip_language_extra))
+if is_maca():
+    import triton_dist.language.extra.maca.language_extra as maca_language_extra
+    proxy_list.append((is_maca, maca_language_extra))
+if is_ascend():
+    import triton_dist.language.extra.ascend.language_extra as ascend_language_extra
+    proxy_list.append((is_ascend, ascend_language_extra))
+
+_extra_module = ModuleProxy(proxy_list)
 
 
 @_extra_module.dispatch

--- a/python/triton_dist/language/extra/libshmem_device.py
+++ b/python/triton_dist/language/extra/libshmem_device.py
@@ -23,443 +23,451 @@
 #
 ################################################################################
 from .utils import ModuleProxy
-from triton_dist.utils import is_cuda, is_rocshmem, is_mori_shmem, is_maca
-import triton_dist.language.extra.cuda.libnvshmem_device as libnvshmem_device
-import triton_dist.language.extra.hip.librocshmem_device as librocshmem_device
-import triton_dist.language.extra.hip.libmori_shmem_device as libmori_shmem_device
-import triton_dist.language.extra.maca.libmxshmem_device as libmxshmem_device
+from triton_dist.utils import is_ascend, is_cuda, is_rocshmem, is_mori_shmem, is_maca
+
+proxy_list = []
+if is_cuda():
+    import triton_dist.language.extra.cuda.libnvshmem_device as libnvshmem_device
+    proxy_list.append((is_cuda, libnvshmem_device))
+if is_rocshmem():
+    import triton_dist.language.extra.hip.librocshmem_device as librocshmem_device
+    proxy_list.append((is_rocshmem, librocshmem_device))
+if is_mori_shmem():
+    import triton_dist.language.extra.hip.libmori_shmem_device as libmori_shmem_device
+    proxy_list.append((is_mori_shmem, libmori_shmem_device))
+if is_maca():
+    import triton_dist.language.extra.maca.libmxshmem_device as libmxshmem_device
+    proxy_list.append((is_maca, libmxshmem_device))
+if is_ascend():
+    import triton_dist.language.extra.ascend.libaclshmem_device as libaclshmem_device
+    proxy_list.append((is_ascend, libaclshmem_device))
 
 import sys
 
-_shmem_module = ModuleProxy([
-    (is_cuda, libnvshmem_device),
-    (is_rocshmem, librocshmem_device),
-    (is_mori_shmem, libmori_shmem_device),
-    (is_maca, libmxshmem_device),
-])
+_shmem_module = ModuleProxy(proxy_list)
 
 
 @_shmem_module.dispatch
-def set_rocshmem_ctx(ctx):
+def set_rocshmem_ctx(ctx, _semantic=None):
     """ROCSHMEM only"""
     ...
 
 
 @_shmem_module.dispatch
-def my_pe():
+def my_pe(_semantic=None):
     """Both NVSHMEM and ROCSHMEM"""
     ...
 
 
 @_shmem_module.dispatch
-def n_pes():
+def n_pes(_semantic=None):
     """Both NVSHMEM and ROCSHMEM"""
     ...
 
 
 @_shmem_module.dispatch
-def team_my_pe(team):
+def team_my_pe(team, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def team_n_pes(team):
+def team_n_pes(team, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def int_p(dest, value, pe, qp_id=0):
+def int_p(dest, value, pe, qp_id=0, _semantic=None):
     """Both NVSHMEM and ROCSHMEM"""
     ...
 
 
 @_shmem_module.dispatch
-def remote_ptr(local_ptr, pe):
+def remote_ptr(local_ptr, pe, _semantic=None):
     """Both NVSHMEM and ROCSHMEM"""
     ...
 
 
 @_shmem_module.dispatch
-def remote_mc_ptr(team, ptr):
+def remote_mc_ptr(team, ptr, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def barrier_all():
+def barrier_all(_semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def barrier_all_block():
+def barrier_all_vec(_semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def barrier_all_warp():
+def barrier_all_block(_semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def barrier_all_wave():
+def barrier_all_warp(_semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def barrier_all_wg():
+def barrier_all_wave(_semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def barrier(team):
+def barrier_all_wg(_semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def barrier_block(team):
+def barrier(team, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def barrier_warp(team):
+def barrier_block(team, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def sync_all():
+def barrier_warp(team, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def sync_all_block():
+def sync_all(_semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def sync_all_warp():
+def sync_all_block(_semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def team_sync_block(team):
+def sync_all_warp(_semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def team_sync_warp(team):
+def team_sync_block(team, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def quiet():
+def team_sync_warp(team, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def quiet_pe():
+def quiet(_semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def fence():
+def quiet_pe(_semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def getmem_nbi_block(dest, source, bytes, pe):
+def fence(_semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def getmem_block(dest, source, bytes, pe):
+def getmem_nbi_block(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def getmem_nbi_warp(dest, source, bytes, pe):
+def getmem_block(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def getmem_warp(dest, source, bytes, pe):
+def getmem_nbi_warp(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def getmem_nbi(dest, source, bytes, pe):
+def getmem_warp(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def getmem_nbi_wave(dest, source, bytes, pe):
+def getmem_nbi(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def getmem_nbi_wg(dest, source, bytes, pe):
+def getmem_nbi_wave(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def getmem(dest, source, bytes, pe):
+def getmem_nbi_wg(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def getmem_wave(dest, source, bytes, pe):
+def getmem(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def getmem_wg(dest, source, bytes, pe):
+def getmem_wave(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_block(dest, source, bytes, pe):
+def getmem_wg(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_nbi_block(dest, source, bytes, pe):
+def putmem_block(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_warp(dest, source, bytes, pe):
+def putmem_nbi_block(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_nbi_warp(dest, source, bytes, pe):
+def putmem_warp(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem(dest, source, bytes, pe):
+def putmem_nbi_warp(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_wave(dest, source, bytes, pe):
+def putmem(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_wg(dest, source, bytes, pe):
+def putmem_wave(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_nbi(dest, source, bytes, pe, qp_id=0):
+def putmem_wg(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_nbi_wave(dest, source, bytes, pe):
+def putmem_nbi(dest, source, bytes, pe, qp_id=0, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_nbi_wg(dest, source, bytes, pe):
+def putmem_nbi_wave(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_nbi(dest, source, bytes, sig_addr, signal, sig_op, pe):
+def putmem_nbi_wg(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal(dest, source, bytes, sig_addr, signal, sig_op, pe):
+def putmem_signal_nbi(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_nbi_block(dest, source, bytes, sig_addr, signal, sig_op, pe, qp_id=0):
+def putmem_signal_nbi_block(dest, source, bytes, sig_addr, signal, sig_op, pe, qp_id=0, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_block(dest, source, bytes, sig_addr, signal, sig_op, pe):
+def putmem_signal_nbi_block(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_nbi_warp(dest, source, bytes, sig_addr, signal, sig_op, pe):
+def putmem_signal_block(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_warp(dest, source, bytes, sig_addr, signal, sig_op, pe):
+def putmem_signal_nbi_warp(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_wave(dest, source, bytes, sig_addr, signal, sig_op, pe):
+def putmem_signal_warp(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_wg(dest, source, bytes, sig_addr, signal, sig_op, pe):
+def putmem_signal_wave(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_nbi_wave(dest, source, bytes, sig_addr, signal, sig_op, pe):
+def putmem_signal_wg(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_nbi_wg(dest, source, bytes, sig_addr, signal, sig_op, pe):
+def putmem_signal_nbi_wave(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def signal_op(sig_addr, signal, sig_op, pe):
+def putmem_signal_nbi_wg(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def signal_wait_until(sig_addr, cmp_, cmp_val):
+def signal_op(sig_addr, signal, sig_op, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def uint64_wait_until_equals(addr, val):
+def uint64_wait_until_equals(addr, val, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def ulong_put_signal(dest, source, nelems, sig_addr, signal, sig_op, pe):
+def ulong_put_signal(dest, source, nelems, sig_addr, signal, sig_op, pe, _semantic=None):
     ...
 
 
 # DON'T USE THIS. NVSHMEM 3.2.5 does not implement this
 @_shmem_module.dispatch
-def broadcastmem(team, dest, source, nelems, pe_root):
+def broadcastmem(team, dest, source, nelems, pe_root, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def broadcastmem_warp(team, dest, source, nelems, pe_root):
+def broadcastmem_warp(team, dest, source, nelems, pe_root, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def broadcastmem_block(team, dest, source, nelems, pe_root):
+def broadcastmem_block(team, dest, source, nelems, pe_root, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def broadcast(team, dest, source, nelems, pe_root):
+def broadcast(team, dest, source, nelems, pe_root, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def broadcast_warp(team, dest, source, nelems, pe_root):
+def broadcast_warp(team, dest, source, nelems, pe_root, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def broadcast_block(team, dest, source, nelems, pe_root):
+def broadcast_block(team, dest, source, nelems, pe_root, _semantic=None):
     ...
 
 
 # DON'T USE THIS. NVSHMEM 3.2.5 does not implement this
 @_shmem_module.dispatch
-def fcollectmem(team, dest, source, nelems):
+def fcollectmem(team, dest, source, nelems, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def fcollectmem_warp(team, dest, source, nelems):
+def fcollectmem_warp(team, dest, source, nelems, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def fcollectmem_block(team, dest, source, nelems):
+def fcollectmem_block(team, dest, source, nelems, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def fcollect(team, dest, source, nelems):
+def fcollect(team, dest, source, nelems, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def fcollect_warp(team, dest, source, nelems):
+def fcollect_warp(team, dest, source, nelems, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def fcollect_block(team, dest, source, nelems):
+def fcollect_block(team, dest, source, nelems, _semantic=None):
     ...
 
 
 ### putmem_rma_* and putmem_signal_rma_* requires nvshmemi_* APIs. and you have to compile the .bc file yourself with shmem/nvshmem_bind/nvshmemi/build_nvshmemi_bc.sh
 @_shmem_module.dispatch
-def putmem_rma(dest, source, bytes, pe):
+def putmem_rma(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_rma_block(dest, source, bytes, pe):
+def putmem_rma_block(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_rma_warp(dest, source, bytes, pe):
+def putmem_rma_warp(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_rma_nbi(dest, source, bytes, pe):
+def putmem_rma_nbi(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_rma_nbi_block(dest, source, bytes, pe):
+def putmem_rma_nbi_block(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_rma_nbi_warp(dest, source, bytes, pe):
+def putmem_rma_nbi_warp(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_rma(dest, source, bytes, sig_addr, signal, sig_op, pe):
+def putmem_signal_rma(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_rma_nbi(dest, source, bytes, sig_addr, signal, sig_op, pe):
+def putmem_signal_rma_nbi(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_rma_warp(dest, source, bytes, sig_addr, signal, sig_op, pe):
+def putmem_signal_rma_warp(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_rma_nbi_warp(dest, source, bytes, sig_addr, signal, sig_op, pe):
+def putmem_signal_rma_nbi_warp(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_rma_block(dest, source, bytes, sig_addr, signal, sig_op, pe):
+def putmem_signal_rma_block(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_rma_nbi_block(dest, source, bytes, sig_addr, signal, sig_op, pe):
+def putmem_signal_rma_nbi_block(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
     ...
 
 
 # TEAM translate
 @_shmem_module.dispatch
-def team_translate_pe(src_team, pe_in_src_team, dest_team):
+def team_translate_pe(src_team, pe_in_src_team, dest_team, _semantic=None):
     ...
 
 

--- a/python/triton_dist/language/extra/libshmem_device.py
+++ b/python/triton_dist/language/extra/libshmem_device.py
@@ -23,443 +23,456 @@
 #
 ################################################################################
 from .utils import ModuleProxy
-from triton_dist.utils import is_cuda, is_rocshmem, is_mori_shmem, is_maca
-import triton_dist.language.extra.cuda.libnvshmem_device as libnvshmem_device
-import triton_dist.language.extra.hip.librocshmem_device as librocshmem_device
-import triton_dist.language.extra.hip.libmori_shmem_device as libmori_shmem_device
-import triton_dist.language.extra.maca.libmxshmem_device as libmxshmem_device
+from triton_dist.utils import is_ascend, is_cuda, is_rocshmem, is_mori_shmem, is_maca
+
+proxy_list = []
+if is_cuda():
+    import triton_dist.language.extra.cuda.libnvshmem_device as libnvshmem_device
+    proxy_list.append((is_cuda, libnvshmem_device))
+if is_rocshmem():
+    import triton_dist.language.extra.hip.librocshmem_device as librocshmem_device
+    proxy_list.append((is_rocshmem, librocshmem_device))
+if is_mori_shmem():
+    import triton_dist.language.extra.hip.libmori_shmem_device as libmori_shmem_device
+    proxy_list.append((is_mori_shmem, libmori_shmem_device))
+if is_maca():
+    import triton_dist.language.extra.maca.libmxshmem_device as libmxshmem_device
+    proxy_list.append((is_maca, libmxshmem_device))
+if is_ascend():
+    import triton_dist.language.extra.ascend.libaclshmem_device as libaclshmem_device
+    proxy_list.append((is_ascend, libaclshmem_device))
 
 import sys
 
-_shmem_module = ModuleProxy([
-    (is_cuda, libnvshmem_device),
-    (is_rocshmem, librocshmem_device),
-    (is_mori_shmem, libmori_shmem_device),
-    (is_maca, libmxshmem_device),
-])
+_shmem_module = ModuleProxy(proxy_list)
 
 
 @_shmem_module.dispatch
-def set_rocshmem_ctx(ctx):
+def set_rocshmem_ctx(ctx, _semantic=None):
     """ROCSHMEM only"""
     ...
 
 
 @_shmem_module.dispatch
-def my_pe():
+def my_pe(_semantic=None):
     """Both NVSHMEM and ROCSHMEM"""
     ...
 
 
 @_shmem_module.dispatch
-def n_pes():
+def n_pes(_semantic=None):
     """Both NVSHMEM and ROCSHMEM"""
     ...
 
 
 @_shmem_module.dispatch
-def team_my_pe(team):
+def team_my_pe(team, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def team_n_pes(team):
+def team_n_pes(team, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def int_p(dest, value, pe, qp_id=0):
+def int_p(dest, value, pe, qp_id=0, _semantic=None):
     """Both NVSHMEM and ROCSHMEM"""
     ...
 
 
 @_shmem_module.dispatch
-def remote_ptr(local_ptr, pe):
+def remote_ptr(local_ptr, pe, _semantic=None):
     """Both NVSHMEM and ROCSHMEM"""
     ...
 
 
 @_shmem_module.dispatch
-def remote_mc_ptr(team, ptr):
+def remote_mc_ptr(team, ptr, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def barrier_all():
+def barrier_all(_semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def barrier_all_block():
+def barrier_all_vec(_semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def barrier_all_warp():
+def barrier_all_block(_semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def barrier_all_wave():
+def barrier_all_warp(_semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def barrier_all_wg():
+def barrier_all_wave(_semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def barrier(team):
+def barrier_all_wg(_semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def barrier_block(team):
+def barrier(team, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def barrier_warp(team):
+def barrier_block(team, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def sync_all():
+def barrier_warp(team, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def sync_all_block():
+def sync_all(_semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def sync_all_warp():
+def sync_all_block(_semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def team_sync_block(team):
+def sync_all_warp(_semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def team_sync_warp(team):
+def team_sync_block(team, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def quiet():
+def team_sync_warp(team, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def quiet_pe():
+def quiet(_semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def fence():
+def quiet_pe(_semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def getmem_nbi_block(dest, source, bytes, pe):
+def fence(_semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def getmem_block(dest, source, bytes, pe):
+def getmem_nbi_block(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def getmem_nbi_warp(dest, source, bytes, pe):
+def getmem_block(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def getmem_warp(dest, source, bytes, pe):
+def getmem_nbi_warp(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def getmem_nbi(dest, source, bytes, pe):
+def getmem_warp(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def getmem_nbi_wave(dest, source, bytes, pe):
+def getmem_nbi(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def getmem_nbi_wg(dest, source, bytes, pe):
+def getmem_nbi_wave(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def getmem(dest, source, bytes, pe):
+def getmem_nbi_wg(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def getmem_wave(dest, source, bytes, pe):
+def getmem(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def getmem_wg(dest, source, bytes, pe):
+def getmem_wave(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_block(dest, source, bytes, pe):
+def getmem_wg(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_nbi_block(dest, source, bytes, pe):
+def putmem_block(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_warp(dest, source, bytes, pe):
+def putmem_nbi_block(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_nbi_warp(dest, source, bytes, pe):
+def putmem_warp(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem(dest, source, bytes, pe):
+def putmem_nbi_warp(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_wave(dest, source, bytes, pe):
+def putmem(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_wg(dest, source, bytes, pe):
+def putmem_wave(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_nbi(dest, source, bytes, pe, qp_id=0):
+def putmem_wg(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_nbi_wave(dest, source, bytes, pe):
+def putmem_nbi(dest, source, bytes, pe, qp_id=0, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_nbi_wg(dest, source, bytes, pe):
+def putmem_nbi_wave(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_nbi(dest, source, bytes, sig_addr, signal, sig_op, pe):
+def putmem_nbi_wg(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal(dest, source, bytes, sig_addr, signal, sig_op, pe):
+def putmem_signal_nbi(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_nbi_block(dest, source, bytes, sig_addr, signal, sig_op, pe, qp_id=0):
+def putmem_signal(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_block(dest, source, bytes, sig_addr, signal, sig_op, pe):
+def putmem_signal_nbi_block(dest, source, bytes, sig_addr, signal, sig_op, pe, qp_id=0, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_nbi_warp(dest, source, bytes, sig_addr, signal, sig_op, pe):
+def putmem_signal_block(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_warp(dest, source, bytes, sig_addr, signal, sig_op, pe):
+def putmem_signal_nbi_warp(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_wave(dest, source, bytes, sig_addr, signal, sig_op, pe):
+def putmem_signal_warp(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_wg(dest, source, bytes, sig_addr, signal, sig_op, pe):
+def putmem_signal_wave(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_nbi_wave(dest, source, bytes, sig_addr, signal, sig_op, pe):
+def putmem_signal_wg(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_nbi_wg(dest, source, bytes, sig_addr, signal, sig_op, pe):
+def putmem_signal_nbi_wave(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def signal_op(sig_addr, signal, sig_op, pe):
+def putmem_signal_nbi_wg(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def signal_wait_until(sig_addr, cmp_, cmp_val):
+def signal_op(sig_addr, signal, sig_op, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def uint64_wait_until_equals(addr, val):
+def signal_wait_until(sig_addr, cmp_, cmp_val, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def ulong_put_signal(dest, source, nelems, sig_addr, signal, sig_op, pe):
+def uint64_wait_until_equals(addr, val, _semantic=None):
+    ...
+
+
+@_shmem_module.dispatch
+def ulong_put_signal(dest, source, nelems, sig_addr, signal, sig_op, pe, _semantic=None):
     ...
 
 
 # DON'T USE THIS. NVSHMEM 3.2.5 does not implement this
 @_shmem_module.dispatch
-def broadcastmem(team, dest, source, nelems, pe_root):
+def broadcastmem(team, dest, source, nelems, pe_root, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def broadcastmem_warp(team, dest, source, nelems, pe_root):
+def broadcastmem_warp(team, dest, source, nelems, pe_root, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def broadcastmem_block(team, dest, source, nelems, pe_root):
+def broadcastmem_block(team, dest, source, nelems, pe_root, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def broadcast(team, dest, source, nelems, pe_root):
+def broadcast(team, dest, source, nelems, pe_root, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def broadcast_warp(team, dest, source, nelems, pe_root):
+def broadcast_warp(team, dest, source, nelems, pe_root, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def broadcast_block(team, dest, source, nelems, pe_root):
+def broadcast_block(team, dest, source, nelems, pe_root, _semantic=None):
     ...
 
 
 # DON'T USE THIS. NVSHMEM 3.2.5 does not implement this
 @_shmem_module.dispatch
-def fcollectmem(team, dest, source, nelems):
+def fcollectmem(team, dest, source, nelems, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def fcollectmem_warp(team, dest, source, nelems):
+def fcollectmem_warp(team, dest, source, nelems, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def fcollectmem_block(team, dest, source, nelems):
+def fcollectmem_block(team, dest, source, nelems, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def fcollect(team, dest, source, nelems):
+def fcollect(team, dest, source, nelems, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def fcollect_warp(team, dest, source, nelems):
+def fcollect_warp(team, dest, source, nelems, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def fcollect_block(team, dest, source, nelems):
+def fcollect_block(team, dest, source, nelems, _semantic=None):
     ...
 
 
 ### putmem_rma_* and putmem_signal_rma_* requires nvshmemi_* APIs. and you have to compile the .bc file yourself with shmem/nvshmem_bind/nvshmemi/build_nvshmemi_bc.sh
 @_shmem_module.dispatch
-def putmem_rma(dest, source, bytes, pe):
+def putmem_rma(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_rma_block(dest, source, bytes, pe):
+def putmem_rma_block(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_rma_warp(dest, source, bytes, pe):
+def putmem_rma_warp(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_rma_nbi(dest, source, bytes, pe):
+def putmem_rma_nbi(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_rma_nbi_block(dest, source, bytes, pe):
+def putmem_rma_nbi_block(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_rma_nbi_warp(dest, source, bytes, pe):
+def putmem_rma_nbi_warp(dest, source, bytes, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_rma(dest, source, bytes, sig_addr, signal, sig_op, pe):
+def putmem_signal_rma(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_rma_nbi(dest, source, bytes, sig_addr, signal, sig_op, pe):
+def putmem_signal_rma_nbi(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_rma_warp(dest, source, bytes, sig_addr, signal, sig_op, pe):
+def putmem_signal_rma_warp(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_rma_nbi_warp(dest, source, bytes, sig_addr, signal, sig_op, pe):
+def putmem_signal_rma_nbi_warp(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_rma_block(dest, source, bytes, sig_addr, signal, sig_op, pe):
+def putmem_signal_rma_block(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_rma_nbi_block(dest, source, bytes, sig_addr, signal, sig_op, pe):
+def putmem_signal_rma_nbi_block(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
     ...
 
 
 # TEAM translate
 @_shmem_module.dispatch
-def team_translate_pe(src_team, pe_in_src_team, dest_team):
+def team_translate_pe(src_team, pe_in_src_team, dest_team, _semantic=None):
     ...
 
 

--- a/python/triton_dist/test/ascend/README.md
+++ b/python/triton_dist/test/ascend/README.md
@@ -1,0 +1,13 @@
+### 使用方式
+
+1. **编译项目**
+   在 `Triton-distributed/` 根目录下执行编译脚本：
+   ```bash
+   LLVM_SYSPATH=${LLVM_INSTALL_PREFIX} TRITON_BUILD_WITH_CLANG_LLD=ON TRITON_BUILD_PROTON=OFF TRITON_BUILD_LITTLE_KERNEL=OFF TRITON_APPEND_CMAKE_ARGS="-DTRITON_BUILD_UT=OFF" pip install -e ./python --verbose --no-build-isolation
+   ```
+
+1. **运行示例程序**
+   进入示例目录并执行运行脚本：
+   ```bash
+   pytest python/triton_dist/test/ascend/ -m dist
+   ```

--- a/python/triton_dist/test/ascend/README.md
+++ b/python/triton_dist/test/ascend/README.md
@@ -1,0 +1,13 @@
+### Usage
+
+1. **Build the project**
+   Run the build script from the `Triton-distributed/` root directory:
+```bash
+   LLVM_SYSPATH=${LLVM_INSTALL_PREFIX} TRITON_BUILD_WITH_CLANG_LLD=ON TRITON_BUILD_PROTON=OFF TRITON_BUILD_LITTLE_KERNEL=OFF TRITON_APPEND_CMAKE_ARGS="-DTRITON_BUILD_UT=OFF" pip install -e ./python --verbose --no-build-isolation
+```
+
+1. **Run the example program**
+   Navigate to the example directory and execute the run script:
+```bash
+   pytest python/triton_dist/test/ascend/ -m dist
+```

--- a/python/triton_dist/test/ascend/conftest.py
+++ b/python/triton_dist/test/ascend/conftest.py
@@ -1,0 +1,63 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+import os
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+
+def _worker_wrapper(rank, world_size, backend, fn, args, error_queue):
+    """
+    每个 worker 进程的通用入口。
+    成功时正常退出，失败时把异常推入 error_queue。
+    """
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = "29500"
+    try:
+        torch.npu.set_device(rank)
+        dist.init_process_group(
+            backend=backend,
+            rank=rank,
+            world_size=world_size,
+        )
+        fn(rank, world_size, *args)
+    except Exception as e:
+        error_queue.put((rank, e))
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
+def run_dist_test(fn, world_size=2, backend="hccl", args=()):
+    """
+    在 world_size 个进程里执行 fn(rank, world_size, *args)。
+    任意 rank 抛异常，测试失败并展示原始错误。
+    """
+    ctx = mp.get_context("spawn")
+    error_queue = ctx.Queue()
+
+    mp.spawn(
+        _worker_wrapper,
+        args=(world_size, backend, fn, args, error_queue),
+        nprocs=world_size,
+        join=True,
+    )
+
+    # 收集所有 rank 的错误
+    errors = []
+    while not error_queue.empty():
+        errors.append(error_queue.get())
+
+    if errors:
+        msgs = "\n".join(f"[rank {r}] {e}" for r, e in errors)
+        pytest.fail(f"分布式 worker 报错:\n{msgs}")
+
+
+@pytest.fixture
+def dist_test():
+    """
+    用法:
+        def test_xxx(dist_test):
+            dist_test(my_worker_fn, world_size=2)
+    """
+    return run_dist_test

--- a/python/triton_dist/test/ascend/conftest.py
+++ b/python/triton_dist/test/ascend/conftest.py
@@ -1,0 +1,63 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+import os
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+
+def _worker_wrapper(rank, world_size, backend, fn, args, error_queue):
+    """
+    Common entry point for each worker process.
+    Exits normally on success; on failure, pushes the exception into error_queue.
+    """
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = "29500"
+    try:
+        torch.npu.set_device(rank)
+        dist.init_process_group(
+            backend=backend,
+            rank=rank,
+            world_size=world_size,
+        )
+        fn(rank, world_size, *args)
+    except Exception as e:
+        error_queue.put((rank, e))
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
+def run_dist_test(fn, world_size=2, backend="hccl", args=()):
+    """
+    Executes fn(rank, world_size, *args) across world_size processes.
+    If any rank raises an exception, the test fails and the original error is shown.
+    """
+    ctx = mp.get_context("spawn")
+    error_queue = ctx.Queue()
+
+    mp.spawn(
+        _worker_wrapper,
+        args=(world_size, backend, fn, args, error_queue),
+        nprocs=world_size,
+        join=True,
+    )
+
+    # Collect errors from all ranks
+    errors = []
+    while not error_queue.empty():
+        errors.append(error_queue.get())
+
+    if errors:
+        msgs = "\n".join(f"[rank {r}] {e}" for r, e in errors)
+        pytest.fail(f"Distributed worker error:\n{msgs}")
+
+
+@pytest.fixture
+def dist_test():
+    """
+    Usage:
+        def test_xxx(dist_test):
+            dist_test(my_worker_fn, world_size=2)
+    """
+    return run_dist_test

--- a/python/triton_dist/test/ascend/test_my_pe.py
+++ b/python/triton_dist/test/ascend/test_my_pe.py
@@ -1,0 +1,58 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+import pytest
+import torch
+import shmem as ash
+import torch.distributed as dist
+import triton
+import triton.language as tl
+import triton_dist.language as dl
+from triton.language.extra.cann.extension import sub_vec_id
+
+g_ash_size = 1024 * 1024 * 1024
+g_malloc_size = 8 * 1024 * 1024
+G_IP_PORT = "tcp://127.0.0.1:8666"
+
+
+def torch_mype(x0, rank, ncore):
+    y_ref = x0.cpu()
+    for i in range(ncore):
+        y_ref[i] += rank
+    return y_ref
+
+
+@triton.jit
+def _shmemx_get_my_pe(ptr):
+    subblock_idx = sub_vec_id()
+    if subblock_idx == 0:
+        mype = dl.rank()
+        offset = tl.program_id(0)
+        tmp0 = tl.load(ptr + offset, None)
+        tmp2 = tmp0 + mype
+        tl.store(ptr + offset, tmp2, None)
+
+
+def run_test_distributed(rank, world_size):
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    ret = ash.set_conf_store_tls(False, "")
+    if ret != 0:
+        raise ValueError("[ERROR] set_conf_store_tls failed")
+    attributes = ash.InitAttr()
+    attributes.my_rank = rank
+    attributes.n_ranks = world_size
+    attributes.local_mem_size = g_ash_size
+    attributes.ip_port = G_IP_PORT
+    attributes.option_attr.data_op_engine_type = ash.OpEngineType.MTE
+    ret = ash.aclshmem_init(attributes)
+    if ret != 0:
+        raise ValueError("[ERROR] aclshmem_init failed")
+    x0 = torch.zeros([32], dtype=torch.int64).npu()
+    y_ref = torch_mype(x0, rank, 3)
+    _shmemx_get_my_pe[3, 1, 1](x0)
+    assert torch.equal(x0.cpu(), y_ref.cpu())
+    _ = ash.aclshmem_finialize()
+
+
+@pytest.mark.dist
+def test_mype(dist_test):
+    dist_test(run_test_distributed, world_size=2)

--- a/python/triton_dist/test/ascend/test_num_ranks.py
+++ b/python/triton_dist/test/ascend/test_num_ranks.py
@@ -1,0 +1,58 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+import pytest
+import torch
+import shmem as ash
+import torch.distributed as dist
+import triton
+import triton.language as tl
+import triton_dist.language as dl
+from triton.language.extra.cann.extension import sub_vec_id
+
+g_ash_size = 1024 * 1024 * 1024
+g_malloc_size = 8 * 1024 * 1024
+G_IP_PORT = "tcp://127.0.0.1:8666"
+
+
+def torch_num_ranks(x0, world_size, ncore):
+    y_ref = x0.cpu()
+    for i in range(ncore):
+        y_ref[i] += world_size
+    return y_ref
+
+
+@triton.jit
+def _shmemx_get_num_ranks(ptr):
+    subblock_idx = sub_vec_id()
+    if subblock_idx == 0:
+        num_ranks = dl.num_ranks()
+        offset = tl.program_id(0)
+        tmp0 = tl.load(ptr + offset, None)
+        tmp2 = tmp0 + num_ranks
+        tl.store(ptr + offset, tmp2, None)
+
+
+def run_test_distributed(rank, world_size):
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    ret = ash.set_conf_store_tls(False, "")
+    if ret != 0:
+        raise ValueError("[ERROR] set_conf_store_tls failed")
+    attributes = ash.InitAttr()
+    attributes.my_rank = rank
+    attributes.n_ranks = world_size
+    attributes.local_mem_size = g_ash_size
+    attributes.ip_port = G_IP_PORT
+    attributes.option_attr.data_op_engine_type = ash.OpEngineType.MTE
+    ret = ash.aclshmem_init(attributes)
+    if ret != 0:
+        raise ValueError("[ERROR] aclshmem_init failed")
+    x0 = torch.zeros([32], dtype=torch.int64).npu()
+    y_ref = torch_num_ranks(x0, world_size, 3)
+    _shmemx_get_num_ranks[3, 1, 1](x0)
+    assert torch.equal(x0.cpu(), y_ref.cpu())
+    _ = ash.aclshmem_finialize()
+
+
+@pytest.mark.dist
+def test_num_ranks(dist_test):
+    dist_test(run_test_distributed, world_size=2)

--- a/python/triton_dist/test/ascend/test_symm_at.py
+++ b/python/triton_dist/test/ascend/test_symm_at.py
@@ -1,0 +1,80 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+import pytest
+import torch
+import shmem as ash
+import torch.distributed as dist
+import triton
+import triton.language as tl
+import triton_dist.language as dl
+from triton_dist.language.extra import libshmem_device
+from triton.language.extra.cann.extension import sub_vec_id
+
+g_ash_size = 1024 * 1024 * 1024
+g_malloc_size = 8 * 1024 * 1024
+G_IP_PORT = "tcp://127.0.0.1:8666"
+
+
+@triton.jit
+def _shmemx_symm_at(remote_ptr, output_ptr, rank, world_size):
+    """Test symm_at by reading data from remote rank"""
+    subblock_idx = sub_vec_id()
+    if subblock_idx == 0:
+        # Get target rank (circular)
+        target_rank = (rank + 1) % world_size
+
+        # Use symm_at to get pointer to remote memory
+        remote_mem_ptr = dl.symm_at(remote_ptr, target_rank)
+
+        # Load data from remote memory
+        offset = tl.arange(0, 32)
+        data = tl.load(remote_mem_ptr + offset, None)
+
+        # Store to output
+        tl.store(output_ptr + offset, data, None)
+    libshmem_device.barrier_all_vec()
+
+
+def run_test_distributed(rank, world_size):
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    ret = ash.set_conf_store_tls(False, "")
+    if ret != 0:
+        raise ValueError("[ERROR] set_conf_store_tls failed")
+    attributes = ash.InitAttr()
+    attributes.my_rank = rank
+    attributes.n_ranks = world_size
+    attributes.local_mem_size = g_ash_size
+    attributes.ip_port = G_IP_PORT
+    attributes.option_attr.data_op_engine_type = ash.OpEngineType.MTE
+    ret = ash.aclshmem_init(attributes)
+    if ret != 0:
+        raise ValueError("[ERROR] aclshmem_init failed")
+
+    # Create local data
+    local_data = torch.arange(32, dtype=torch.int64).npu() + rank * 100
+    output = torch.zeros(32, dtype=torch.int64).npu()
+
+    # Create shared memory for remote access
+    remote_mem = ash.aclshmem_create_tensor([32], dtype=torch.int64, device_id=rank)
+    remote_mem.copy_(local_data)
+
+    # Gather all remote data for reference
+    all_data = [torch.zeros(32, dtype=torch.int64) for _ in range(world_size)]
+    dist.all_gather_object(all_data, local_data.cpu())
+
+    # Run kernel
+    _shmemx_symm_at[1, 1, 1](remote_mem, output, rank, world_size)
+
+    # Verify result
+    target_rank = (rank + 1) % world_size
+    expected = all_data[target_rank]
+    assert torch.equal(output.cpu(), expected), f"Rank {rank}: output mismatch"
+
+    # Cleanup
+    ash.aclshmem_free_tensor(remote_mem)
+    _ = ash.aclshmem_finialize()
+
+
+@pytest.mark.dist
+def test_symm_at(dist_test):
+    dist_test(run_test_distributed, world_size=2)

--- a/python/triton_dist/test/ascend/test_wait_notify.py
+++ b/python/triton_dist/test/ascend/test_wait_notify.py
@@ -1,0 +1,104 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+import pytest
+import torch
+import shmem as ash
+import torch.distributed as dist
+import triton
+import triton.language as tl
+import triton_dist.language as dl
+from triton.language.extra.cann.extension import sub_vec_id
+
+g_ash_size = 1024 * 1024 * 1024
+g_malloc_size = 8 * 1024 * 1024
+G_IP_PORT = "tcp://127.0.0.1:8666"
+
+
+@triton.jit
+def _producer_kernel(data_ptr, signal_ptr, rank, world_size):
+    """Producer: write data and notify consumer"""
+    subblock_idx = sub_vec_id()
+    if subblock_idx == 0:
+        # Write data
+        offset = tl.program_id(0)
+        value = rank * 100 + offset
+        data_ptr = dl.symm_at(data_ptr, 0)
+        tl.store(data_ptr + offset, value, None)
+
+        # Notify consumer (rank 0) that data is ready
+        target_rank = 0
+        dl.notify(
+            signal_ptr, target_rank, signal=1, sig_op="set", comm_scope="intra_node"
+        )
+
+
+@triton.jit
+def _consumer_kernel(data_ptr, signal_ptr, output_ptr, rank, world_size):
+    """Consumer: wait for signal, then read data"""
+    subblock_idx = sub_vec_id()
+    if subblock_idx == 0:
+        # Wait for notification from all other ranks
+        num_barriers = world_size - 1  # Wait for all producers
+        barrier_ptrs = signal_ptr
+        token = dl.wait(
+            barrier_ptrs, num_barriers, scope="gpu", semantic="acquire", waitValue=1
+        )
+        data_ptr = dl.consume_token(data_ptr, token)
+        # Read data from all producers
+        offset = tl.program_id(0)
+        data = tl.load(data_ptr + offset, None)
+        tl.store(output_ptr + offset, data, None)
+
+
+def run_test_distributed(rank, world_size):
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    ret = ash.set_conf_store_tls(False, "")
+    if ret != 0:
+        raise ValueError("[ERROR] set_conf_store_tls failed")
+    attributes = ash.InitAttr()
+    attributes.my_rank = rank
+    attributes.n_ranks = world_size
+    attributes.local_mem_size = g_ash_size
+    attributes.ip_port = G_IP_PORT
+    attributes.option_attr.data_op_engine_type = ash.OpEngineType.MTE
+    ret = ash.aclshmem_init(attributes)
+    if ret != 0:
+        raise ValueError("[ERROR] aclshmem_init failed")
+
+    # Create shared memory for data and signals
+    data_mem = ash.aclshmem_create_tensor([32], dtype=torch.int64, device_id=rank)
+    signal_mem = ash.aclshmem_create_tensor([1], dtype=torch.int64, device_id=rank)
+
+    # Initialize signal to 0
+    signal_mem.zero_()
+
+    if rank == 0:
+        # Consumer (rank 0)
+        output = torch.zeros(32, dtype=torch.int64).npu()
+
+        # Run consumer kernel
+        _consumer_kernel[1, 1, 1](data_mem, signal_mem, output, rank, world_size)
+
+        # Verify: output should contain data from the last producer
+        # (since all producers write to same location, last write wins)
+        last_producer = world_size - 1
+        expected = torch.zeros(32, dtype=torch.int64).npu()
+        expected[0] = last_producer * 100
+        assert torch.equal(output.cpu(), expected.cpu()), "Consumer: output mismatch"
+    else:
+        # Producers (rank 1, 2, ...)
+        # Run producer kernel
+        _producer_kernel[1, 1, 1](data_mem, signal_mem, rank, world_size)
+
+    # Synchronize all ranks
+    dist.barrier()
+
+    # Cleanup
+    ash.aclshmem_free_tensor(data_mem)
+    ash.aclshmem_free_tensor(signal_mem)
+    _ = ash.aclshmem_finialize()
+
+
+@pytest.mark.dist
+def test_wait_notify(dist_test):
+    dist_test(run_test_distributed, world_size=2)

--- a/python/triton_dist/test/ascend/test_wait_notify.py
+++ b/python/triton_dist/test/ascend/test_wait_notify.py
@@ -1,0 +1,100 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+import pytest
+import torch
+import shmem as ash
+import torch.distributed as dist
+import triton
+import triton.language as tl
+import triton_dist.language as dl
+from triton.language.extra.cann.extension import sub_vec_id
+
+g_ash_size = 1024 * 1024 * 1024
+g_malloc_size = 8 * 1024 * 1024
+G_IP_PORT = "tcp://127.0.0.1:8666"
+
+
+@triton.jit
+def _producer_kernel(data_ptr, signal_ptr, rank, world_size):
+    """Producer: write data and notify consumer"""
+    subblock_idx = sub_vec_id()
+    if subblock_idx == 0:
+        # Write data
+        offset = tl.program_id(0)
+        value = rank * 100 + offset
+        data_ptr = dl.symm_at(data_ptr, 0)
+        tl.store(data_ptr + offset, value, None)
+
+        # Notify consumer (rank 0) that data is ready
+        target_rank = 0
+        dl.notify(signal_ptr, target_rank, signal=1, sig_op="set", comm_scope="intra_node")
+
+
+@triton.jit
+def _consumer_kernel(data_ptr, signal_ptr, output_ptr, rank, world_size):
+    """Consumer: wait for signal, then read data"""
+    subblock_idx = sub_vec_id()
+    if subblock_idx == 0:
+        # Wait for notification from all other ranks
+        num_barriers = world_size - 1  # Wait for all producers
+        barrier_ptrs = signal_ptr
+        token = dl.wait(barrier_ptrs, num_barriers, scope="gpu", semantic="acquire", waitValue=1)
+        data_ptr = dl.consume_token(data_ptr, token)
+        # Read data from all producers
+        offset = tl.program_id(0)
+        data = tl.load(data_ptr + offset, None)
+        tl.store(output_ptr + offset, data, None)
+
+
+def run_test_distributed(rank, world_size):
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    ret = ash.set_conf_store_tls(False, "")
+    if ret != 0:
+        raise ValueError("[ERROR] set_conf_store_tls failed")
+    attributes = ash.InitAttr()
+    attributes.my_rank = rank
+    attributes.n_ranks = world_size
+    attributes.local_mem_size = g_ash_size
+    attributes.ip_port = G_IP_PORT
+    attributes.option_attr.data_op_engine_type = ash.OpEngineType.MTE
+    ret = ash.aclshmem_init(attributes)
+    if ret != 0:
+        raise ValueError("[ERROR] aclshmem_init failed")
+
+    # Create shared memory for data and signals
+    data_mem = ash.aclshmem_create_tensor([32], dtype=torch.int64, device_id=rank)
+    signal_mem = ash.aclshmem_create_tensor([1], dtype=torch.int64, device_id=rank)
+
+    # Initialize signal to 0
+    signal_mem.zero_()
+
+    if rank == 0:
+        # Consumer (rank 0)
+        output = torch.zeros(32, dtype=torch.int64).npu()
+
+        # Run consumer kernel
+        _consumer_kernel[1, 1, 1](data_mem, signal_mem, output, rank, world_size)
+
+        # Verify: output should contain data from the last producer
+        # (since all producers write to same location, last write wins)
+        last_producer = world_size - 1
+        expected = torch.zeros(32, dtype=torch.int64).npu()
+        expected[0] = last_producer * 100
+        assert torch.equal(output.cpu(), expected.cpu()), "Consumer: output mismatch"
+    else:
+        # Producers (rank 1, 2, ...)
+        # Run producer kernel
+        _producer_kernel[1, 1, 1](data_mem, signal_mem, rank, world_size)
+
+    # Synchronize all ranks
+    dist.barrier()
+
+    # Cleanup
+    ash.aclshmem_free_tensor(data_mem)
+    ash.aclshmem_free_tensor(signal_mem)
+    _ = ash.aclshmem_finialize()
+
+
+@pytest.mark.dist
+def test_wait_notify(dist_test):
+    dist_test(run_test_distributed, world_size=2)

--- a/python/triton_dist/utils.py
+++ b/python/triton_dist/utils.py
@@ -86,6 +86,14 @@ def is_maca():
         return False
 
 
+def is_ascend():
+    """Checks if 'npu-smi' is available on the system's PATH."""
+    if shutil.which("npu-smi"):
+        return True
+    else:
+        return False
+
+
 def get_shmem_backend():
     if is_cuda():
         return 'nvshmem'
@@ -142,6 +150,8 @@ elif is_hip():
                               "export TRITON_DIST_SHMEM_BACKEND=rocshmem")
 elif is_maca():
     from maca import macart
+elif is_ascend():
+    pass
 else:
     raise Exception("either CUDA or HIP platform is supported")
 

--- a/python/triton_dist/utils.py
+++ b/python/triton_dist/utils.py
@@ -86,6 +86,14 @@ def is_maca():
         return False
 
 
+def is_ascend():
+    """Checks if 'npu-smi' is available on the system's PATH."""
+    if shutil.which("npu-smi"):
+        return True
+    else:
+        return False
+
+
 def get_shmem_backend():
     if is_cuda():
         return 'nvshmem'
@@ -142,6 +150,8 @@ elif is_hip():
                               "export TRITON_DIST_SHMEM_BACKEND=rocshmem")
 elif is_maca():
     import triton.pymaca.maca as maca
+elif is_ascend():
+    pass
 else:
     raise Exception("either CUDA or HIP platform is supported")
 
@@ -1020,23 +1030,23 @@ requirement upfront is important.
 
 Usage:
     from ditron_kernel.utils.lazy_allocator import LazyAllocator, LazyTensor
-    
+
     # Create allocator with custom tensor creation function
     allocator = LazyAllocator(
         create_tensor_fn=nvshmem_create_tensor,
         lazy=True
     )
-    
+
     # Create lazy tensors (no actual allocation yet)
     buf1 = allocator.create_tensor("buffer1", [1024, 256], torch.bfloat16)
     buf2 = allocator.create_tensor("buffer2", [512], torch.int32, fill_value=0)
-    
+
     # Query total size before allocation
     print(f"Total memory needed: {allocator.get_total_size_gb():.2f} GB")
-    
+
     # Actually allocate all tensors
     allocator.sync()
-    
+
     # Now tensors can be used normally
     buf1[0] = 1.0
 """
@@ -1084,10 +1094,10 @@ class LazyTensorSpec:
 class LazyTensor:
     """
     A lazy tensor wrapper that delays allocation until sync() is called.
-    
+
     Before sync(): records the shape/dtype, allows querying size
     After sync(): behaves like a normal tensor
-    
+
     This class implements __torch_function__ to be compatible with PyTorch
     operations like torch.empty_like(), torch.zeros_like(), etc.
     """
@@ -1259,7 +1269,7 @@ class LazyTensor:
         """
         Handle PyTorch functions that receive LazyTensor as input.
         Automatically unwrap LazyTensor to underlying tensor.
-        
+
         This makes LazyTensor compatible with functions like:
         - torch.empty_like()
         - torch.zeros_like()
@@ -1289,34 +1299,34 @@ class LazyTensor:
 class LazyAllocator:
     """
     Lazy allocator for tensors.
-    
+
     This allocator can delay tensor allocation until sync() is called,
     allowing users to query the total memory requirement before allocation.
-    
+
     Args:
         create_tensor_fn: Function to create a tensor, signature: (shape, dtype) -> Tensor
         free_tensor_fn: Optional function to free a tensor, signature: (tensor) -> None
         lazy: If True, delay allocation until sync() is called.
               If False, allocate immediately (default behavior).
-    
+
     Usage:
         allocator = LazyAllocator(
             create_tensor_fn=nvshmem_create_tensor,
             free_tensor_fn=nvshmem_free_tensor_sync,
             lazy=True
         )
-        
+
         # Create lazy tensors (no actual allocation)
         tensor1 = allocator.create_tensor("buf1", [1024, 256], torch.bfloat16)
         tensor2 = allocator.create_tensor("buf2", [512], torch.int32)
-        
+
         # Query total size before allocation
         total_bytes = allocator.get_total_size()
         print(f"Total memory needed: {total_bytes / 1e9:.2f} GB")
-        
+
         # Actually allocate all tensors
         allocator.sync()
-        
+
         # Now tensors can be used normally
         tensor1.fill_(0)
     """
@@ -1325,7 +1335,7 @@ class LazyAllocator:
                  free_tensor_fn: Optional[Callable[[torch.Tensor], None]] = None, lazy: bool = False):
         """
         Initialize the allocator.
-        
+
         Args:
             create_tensor_fn: Function to create a tensor, signature: (shape, dtype) -> Tensor
             free_tensor_fn: Optional function to free a tensor, signature: (tensor) -> None
@@ -1353,13 +1363,13 @@ class LazyAllocator:
                       fill_value: Optional[float] = None) -> LazyTensor:
         """
         Create a (potentially lazy) tensor.
-        
+
         Args:
             name: Name for debugging/tracking
             shape: Tensor shape
             dtype: Tensor dtype
             fill_value: Optional value to fill after allocation
-        
+
         Returns:
             LazyTensor that wraps the allocation
         """
@@ -1379,7 +1389,7 @@ class LazyAllocator:
     def get_total_size(self) -> int:
         """
         Get the total size in bytes.
-        
+
         This can be called before sync() to query the total memory needed.
         """
         return self._total_bytes
@@ -1395,7 +1405,7 @@ class LazyAllocator:
     def get_tensor_breakdown(self) -> Dict[str, int]:
         """
         Get a breakdown of memory usage by tensor.
-        
+
         Returns:
             Dict mapping tensor name to size in bytes
         """
@@ -1414,7 +1424,7 @@ class LazyAllocator:
     def sync(self) -> None:
         """
         Materialize all lazy tensors.
-        
+
         This actually allocates the memory for all pending tensors.
         """
         if self._materialized:
@@ -1439,7 +1449,7 @@ class LazyAllocator:
     def free_tensor(self, tensor_or_lazy: Union[LazyTensor, torch.Tensor, None]) -> None:
         """
         Free a tensor using the configured free function.
-        
+
         Handles both LazyTensor and regular torch.Tensor.
         """
         if tensor_or_lazy is None:
@@ -1464,10 +1474,10 @@ class LazyAllocator:
 def get_underlying_tensor(tensor_or_lazy: Union[LazyTensor, torch.Tensor, None]) -> Optional[torch.Tensor]:
     """
     Get the underlying tensor from a LazyTensor or return the tensor as-is.
-    
+
     Args:
         tensor_or_lazy: LazyTensor, torch.Tensor, or None
-    
+
     Returns:
         The underlying torch.Tensor, or None
     """
@@ -1490,24 +1500,24 @@ def nvshmem_free_lazy_tensor(tensor_or_lazy):
 class NVSHMEMLazyAllocator(LazyAllocator):
     """
     Lazy allocator specifically for nvshmem tensors.
-    
+
     This is a convenience wrapper around LazyAllocator that uses
     nvshmem_create_tensor and nvshmem_free_tensor_sync by default.
-    
+
     Usage:
         allocator = NVSHMEMLazyAllocator(lazy=True)
-        
+
         # Create lazy tensors (no actual allocation)
         tensor1 = allocator.create_tensor("buf1", [1024, 256], torch.bfloat16)
         tensor2 = allocator.create_tensor("buf2", [512], torch.int32)
-        
+
         # Query total size before allocation
         total_bytes = allocator.get_total_nvshmem_size()
         print(f"Total nvshmem needed: {total_bytes / 1e9:.2f} GB")
-        
+
         # Actually allocate all tensors
         allocator.sync()
-        
+
         # Now tensors can be used normally
         tensor1.fill_(0)
     """
@@ -1515,7 +1525,7 @@ class NVSHMEMLazyAllocator(LazyAllocator):
     def __init__(self, lazy: bool = False):
         """
         Initialize the nvshmem allocator.
-        
+
         Args:
             lazy: If True, delay allocation until sync() is called.
                   If False, allocate immediately (default behavior).

--- a/tutorials/11-ascend-allgather-gemm.py
+++ b/tutorials/11-ascend-allgather-gemm.py
@@ -1,0 +1,362 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+import os
+import torch
+import torch_npu
+import shmem as ash
+import torch.distributed as dist
+import triton
+import triton.language as tl
+import triton_dist.language as dl
+from triton_dist.language.extra import libshmem_device
+from triton_dist.language.extra.ascend.algorithm import (
+    dist_swizzle2d_Nz,
+    gemm_swizzle2d_Nz,
+)
+from triton.language.extra.cann.extension import sub_vec_id
+import numpy as np
+
+g_ash_size = 1024 * 1024 * 1024
+g_malloc_size = 8 * 1024 * 1024
+G_IP_PORT = "tcp://127.0.0.1:8666"
+
+# ANSI color codes
+GREEN = "\033[92m"
+RED = "\033[91m"
+RESET = "\033[0m"
+BOLD = "\033[1m"
+
+
+@triton.jit
+def kernel_allgather_gemm(
+    # Pointers to matrices
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    peer_mem_ptr,
+    # Distributed parameters
+    rank,
+    rank_size,
+    buffer_num,
+    # Matrix dimensions
+    M,
+    N,
+    K,
+    # The stride variables represent how much to increase the ptr by when moving by 1
+    # element in a particular dimension. E.g. `stride_am` is how much to increase `a_ptr`
+    # by to get the element one row down (A has M rows).
+    stride_am,
+    stride_ak,  #
+    stride_bk,
+    stride_bn,  #
+    stride_cm,
+    stride_cn,
+    # Meta-parameters
+    pvalue: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    COMM_BLOCK_SIZE_M: tl.constexpr,
+    COMM_BLOCK_SIZE_K: tl.constexpr,
+):
+    """Kernel for computing the matmul C = A x B.
+    A has shape (M, K), B has shape (K, N) and C has shape (M, N)
+    """
+    dtype = tl.float16
+    subblock_idx = sub_vec_id()
+    ncore = tl.num_programs(axis=0)
+    pid = tl.program_id(axis=0)
+    num_loops_m = tl.cdiv(M, BLOCK_SIZE_M * pvalue)
+    num_loops_n = tl.cdiv(N, BLOCK_SIZE_N)
+    buffer_row_size = BLOCK_SIZE_M * pvalue * rank_size
+    for global_id_m in range(0, num_loops_m):
+        buffer_id = global_id_m % buffer_num
+        actual_block_size_m = BLOCK_SIZE_M * pvalue
+        # process tail block
+        if global_id_m == num_loops_m - 1:
+            actual_block_size_m = M - global_id_m * BLOCK_SIZE_M * pvalue
+        num_k_blocks = tl.cdiv(K, BLOCK_SIZE_K)
+        comm_num_m_blocks = tl.cdiv(actual_block_size_m, COMM_BLOCK_SIZE_M)
+        comm_num_k_blocks = tl.cdiv(K, COMM_BLOCK_SIZE_K)
+        if subblock_idx == 0:
+            for k in range(
+                pid, comm_num_m_blocks * comm_num_k_blocks * rank_size, ncore
+            ):
+                block_id_m, block_id_k, target_rank, comm_row_shape, comm_col_shape = (
+                    dist_swizzle2d_Nz(
+                        k,
+                        rank_size,
+                        actual_block_size_m,
+                        K,
+                        COMM_BLOCK_SIZE_M,
+                        COMM_BLOCK_SIZE_K,
+                    )
+                )
+                remote_ptr = dl.symm_at(peer_mem_ptr, target_rank)
+                comm_offs_m = (
+                    tl.arange(0, COMM_BLOCK_SIZE_M)
+                    + block_id_m * COMM_BLOCK_SIZE_M
+                    + global_id_m * BLOCK_SIZE_M * pvalue
+                )
+                comm_offs_k = (
+                    tl.arange(0, COMM_BLOCK_SIZE_K) + block_id_k * COMM_BLOCK_SIZE_K
+                )
+                a_ptrs = a_ptr + (
+                    comm_offs_m[:, None] * stride_am + comm_offs_k[None, :] * stride_ak
+                )
+                peermem_comm_offs_m = (
+                    buffer_id * buffer_row_size
+                    + rank * BLOCK_SIZE_M * pvalue
+                    + block_id_m * COMM_BLOCK_SIZE_M
+                    + tl.arange(0, COMM_BLOCK_SIZE_M)
+                )
+                remote_ptrs = remote_ptr + (
+                    peermem_comm_offs_m[:, None] * stride_am
+                    + comm_offs_k[None, :] * stride_ak
+                )
+                comm_msk_m = comm_offs_m[:, None] < M
+                peermem_comm_msk_m = (
+                    peermem_comm_offs_m[:, None]
+                    < buffer_id * buffer_row_size
+                    + BLOCK_SIZE_M * rank * pvalue
+                    + block_id_m * COMM_BLOCK_SIZE_M
+                    + comm_row_shape
+                )
+                a = tl.load(
+                    a_ptrs, mask=(comm_offs_k[None, :] < K) & comm_msk_m, other=0.0
+                )
+                tl.store(
+                    remote_ptrs, a, mask=(comm_offs_k[None, :] < K) & peermem_comm_msk_m
+                )
+        libshmem_device.barrier_all()
+        num_tiles_m = tl.cdiv(actual_block_size_m, BLOCK_SIZE_M)
+        for block_id in range(pid, num_tiles_m * num_loops_n * rank_size, ncore):
+            block_id_m, block_id_n = gemm_swizzle2d_Nz(
+                block_id,
+                rank_size * BLOCK_SIZE_M * num_tiles_m,
+                N,
+                BLOCK_SIZE_M,
+                BLOCK_SIZE_N,
+            )
+            rank_idx = block_id_m // num_tiles_m
+            block_id_m = rank_idx * pvalue + (block_id_m % num_tiles_m)
+            accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+            matmul_offs_am = (
+                buffer_id * buffer_row_size
+                + block_id_m * BLOCK_SIZE_M
+                + tl.arange(0, BLOCK_SIZE_M)
+            )
+            matmul_msk_am = matmul_offs_am[:, None] < (
+                buffer_id * buffer_row_size
+                + BLOCK_SIZE_M * rank_idx * pvalue
+                + actual_block_size_m
+            )
+            offs_bn = block_id_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+            msk_n = offs_bn[None, :] < N
+            for block_id_k in range(0, num_k_blocks):
+                offs_k = tl.arange(0, BLOCK_SIZE_K) + block_id_k * BLOCK_SIZE_K
+                a_ptrs = peer_mem_ptr + (
+                    matmul_offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak
+                )
+                b_ptrs = b_ptr + (
+                    offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn
+                )
+                a = tl.load(
+                    a_ptrs, mask=(offs_k[None, :] < K) & matmul_msk_am, other=0.0
+                )
+                b = tl.load(b_ptrs, mask=(offs_k[:, None] < K) & msk_n, other=0.0)
+                # We accumulate along the K dimension.
+                accumulator += tl.dot(a, b)
+            c = accumulator.to(dtype)
+            # -----------------------------------------------------------
+            # Write back the block of the output matrix C with masks.
+            offs_cm = (
+                block_id_m // pvalue * M
+                + global_id_m * BLOCK_SIZE_M * pvalue
+                + (block_id_m % pvalue) * BLOCK_SIZE_M
+                + tl.arange(0, BLOCK_SIZE_M)
+            )
+            offs_cn = block_id_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+            c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
+            c_mask = (offs_cm[:, None] < M * (block_id_m // pvalue + 1)) & (
+                offs_cn[None, :] < N
+            )
+            tl.store(c_ptrs, c, mask=c_mask)
+
+
+def allgather_gemm(
+    A,
+    B,
+    C,
+    peer_mem,
+    rank,
+    rank_size,
+    buffer_num,
+    pvalue,
+    BLOCK_SIZE_M,
+    BLOCK_SIZE_N,
+    BLOCK_SIZE_K,
+    COMM_BLOCK_SIZE_M,
+    COMM_BLOCK_SIZE_K,
+):
+    """consume gemm"""
+    M, K = A.shape
+    _, N = B.shape
+    ncore = 20
+    assert ncore <= 20, "block num should less than or equal physical aicore num"
+    kernel_allgather_gemm[ncore, 1, 1](
+        A,
+        B,
+        C,
+        peer_mem,
+        rank,
+        rank_size,
+        buffer_num,
+        M,
+        N,
+        K,
+        A.stride(0),
+        A.stride(1),
+        B.stride(0),
+        B.stride(1),
+        C.stride(0),
+        C.stride(1),
+        pvalue,
+        BLOCK_SIZE_M,
+        BLOCK_SIZE_N,
+        BLOCK_SIZE_K,
+        COMM_BLOCK_SIZE_M,
+        COMM_BLOCK_SIZE_K,
+    )
+
+
+def torch_allgather_gemm(A_local, B, world_size):
+    """
+    torch allgather gemm using torch.distributed.all_gather
+    - A_local: local A tensor on this rank
+    - B: B tensor (same across all ranks)
+    - world_size: number of ranks
+    Returns: C_golden computed from all-gathered A tensors
+    """
+    # Create a list to hold gathered A tensors from all ranks
+    A_list = [torch.empty_like(A_local) for _ in range(world_size)]
+
+    # Gather all A tensors from all ranks
+    dist.all_gather(A_list, A_local)
+
+    # Concatenate all A tensors along the first dimension
+    A_golden = torch.cat(A_list, dim=0)
+
+    # Compute golden reference: C = A_golden @ B
+
+    C_golden = torch.matmul(A_golden, B)
+    return C_golden
+
+
+def run_test_distributed():
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 256
+    COMM_BLOCK_SIZE_M = 20
+    COMM_BLOCK_SIZE_K = 256
+    buffer_num = 2
+    pvalue = 4
+    pe = dist.get_rank()
+    world_size = dist.get_world_size()
+    ret = ash.set_conf_store_tls(False, "")
+    if ret != 0:
+        raise ValueError("[ERROR] set_conf_store_tls failed")
+    attributes = ash.InitAttr()
+    attributes.my_rank = pe
+    attributes.n_ranks = world_size
+    attributes.local_mem_size = g_ash_size
+    attributes.ip_port = G_IP_PORT
+    attributes.option_attr.data_op_engine_type = ash.OpEngineType.MTE
+    ret = ash.aclshmem_init(attributes)
+    if ret != 0:
+        raise ValueError("[ERROR] aclshmem_init failed")
+
+    # Calculate peer_mem size based on world_size
+    peer_mem_size = (
+        BLOCK_SIZE_M * pvalue * world_size * buffer_num * max(K, BLOCK_SIZE_K)
+    )
+    peer_mem = ash.aclshmem_create_tensor(
+        [peer_mem_size],
+        dtype=dtype,
+        device_id=pe,
+    )
+
+    # Each rank creates its own local A and B tensors
+    A_local = torch.randn([M, K], dtype=dtype).npu()
+    B = torch.randn([K, N], dtype=dtype).npu()
+    C = torch.zeros([M * world_size, N], dtype=dtype).npu()
+
+    # Compute golden reference using torch.distributed.all_gather
+    C_golden = torch_allgather_gemm(A_local, B, world_size)
+
+    # Run the distributed kernel with local A
+    allgather_gemm(
+        A_local,
+        B,
+        C,
+        peer_mem,
+        pe,
+        world_size,
+        buffer_num,
+        pvalue,
+        BLOCK_SIZE_M,
+        BLOCK_SIZE_N,
+        BLOCK_SIZE_K,
+        COMM_BLOCK_SIZE_M,
+        COMM_BLOCK_SIZE_K,
+    )
+
+    passed = torch.tensor([1], dtype=torch.int32).npu()
+    error_msg = ""
+    try:
+        torch.testing.assert_close(C_golden, C, rtol=1e-3, atol=1e-3)
+    except AssertionError as e:
+        passed[0] = 0
+        error_msg = str(e)
+        raise
+
+    # Gather all ranks' pass/fail status
+    all_passed = [torch.zeros(1, dtype=torch.int32).npu() for _ in range(world_size)]
+    dist.all_gather(all_passed, passed)
+
+    # Print sequentially, one rank at a time
+    dist.barrier()
+    for rank_id in range(world_size):
+        if pe == rank_id:
+            if all_passed[rank_id].item() == 1:
+                print(
+                    f"{GREEN}[PASS]{RESET} Rank {pe}: C_golden and C match within tolerances (rtol=1e-3, atol=1e-3).",
+                    flush=True,
+                )
+            else:
+                print(
+                    f"{RED}[FAIL]{RESET} Rank {pe}: C_golden and C do NOT match. Details:\n{error_msg}",
+                    flush=True,
+                )
+        dist.barrier()
+    # Raise if any rank failed
+    if any(r.item() == 0 for r in all_passed):
+        if passed.item() == 0:
+            raise AssertionError(error_msg)
+
+    ash.aclshmem_free_tensor(peer_mem)
+    _ = ash.aclshmem_finialize()
+
+
+if __name__ == "__main__":
+    local_pe = int(os.environ["LOCAL_RANK"])
+    torch.npu.set_device(local_pe)
+    dist.init_process_group(backend="hccl", rank=local_pe)
+    dtype, M, N, K = [torch.float16, 4096, 4096, 4096]
+    world_size = dist.get_world_size()
+
+    print(f"[INFO] Rank {local_pe} of {world_size} initialized")
+    dist.barrier()
+    run_test_distributed()
+    if local_pe == 0:
+        print(f"[INFO] Test passed successfully for {world_size} ranks!")

--- a/tutorials/12-ascend-gemm-reduce-scatter.py
+++ b/tutorials/12-ascend-gemm-reduce-scatter.py
@@ -1,0 +1,372 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+import os
+import torch
+import torch_npu
+import shmem as ash
+import torch.distributed as dist
+import triton
+import triton.language as tl
+import triton_dist.language as dl
+from triton_dist.language.extra import libshmem_device
+from triton_dist.language.extra.ascend.algorithm import (
+    dist_swizzle2d_Nz,
+    gemm_swizzle2d_Nz,
+)
+from triton.language.extra.cann.extension import sub_vec_id
+import numpy as np
+
+g_ash_size = 1024 * 1024 * 1024
+g_malloc_size = 8 * 1024 * 1024
+G_IP_PORT = "tcp://127.0.0.1:8666"
+
+# ANSI color codes
+GREEN = "\033[92m"
+RED = "\033[91m"
+RESET = "\033[0m"
+BOLD = "\033[1m"
+
+
+@triton.jit
+def kernel_gemm_reduce_scatter(
+    # Pointers to matrices
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    peer_mem_ptr,
+    # Distributed parameters
+    rank,
+    rank_size,
+    buffer_num,
+    # Matrix dimensions
+    M,
+    N,
+    K,
+    # The stride variables represent how much to increase the ptr by when moving by 1
+    # element in a particular dimension. E.g. `stride_am` is how much to increase `a_ptr`
+    # by to get the element one row down (A has M rows).
+    stride_am,
+    stride_ak,  #
+    stride_bk,
+    stride_bn,  #
+    stride_cm,
+    stride_cn,
+    # Meta-parameters
+    pvalue: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    COMM_BLOCK_SIZE_M: tl.constexpr,
+    COMM_BLOCK_SIZE_N: tl.constexpr,
+):
+    """Kernel for computing the matmul C = A x B.
+    A has shape (M, K), B has shape (K, N) and C has shape (M, N)
+    """
+    subblock_idx = sub_vec_id()
+    ncore = tl.num_programs(axis=0)
+    pid = tl.program_id(axis=0)
+    loop_num_per_comm = ncore * pvalue
+    m_per_rank = M // rank_size
+    num_loops_m = tl.cdiv(m_per_rank, BLOCK_SIZE_M) * rank_size
+    num_loops_n = tl.cdiv(N, BLOCK_SIZE_N)
+    total_loops = num_loops_m * num_loops_n
+    num_loops_comm = tl.cdiv(total_loops, loop_num_per_comm)
+    buffer_row_size = BLOCK_SIZE_M * loop_num_per_comm
+    for global_id in range(0, num_loops_comm):
+        buffer_id = global_id % buffer_num
+        actual_loop_num_per_comm = loop_num_per_comm
+        output_block_offset_in_rank = global_id * loop_num_per_comm // rank_size
+        # process tail block
+        if global_id == num_loops_comm - 1:
+            actual_loop_num_per_comm = total_loops - global_id * loop_num_per_comm
+        num_k_blocks = tl.cdiv(K, BLOCK_SIZE_K)
+        num_blocks_per_rank = actual_loop_num_per_comm // rank_size
+        for block_id in range(pid, actual_loop_num_per_comm, ncore):
+            block_id_in_rank = (
+                output_block_offset_in_rank + block_id % num_blocks_per_rank
+            )
+            block_id_m, block_id_n = gemm_swizzle2d_Nz(
+                block_id_in_rank,
+                m_per_rank,
+                N,
+                BLOCK_SIZE_M,
+                BLOCK_SIZE_N,
+            )
+            rank_idx = block_id // num_blocks_per_rank
+            accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+            matmul_offs_am = (
+                m_per_rank * rank_idx
+                + block_id_m * BLOCK_SIZE_M
+                + tl.arange(0, BLOCK_SIZE_M)
+            )
+            matmul_msk_am = matmul_offs_am[:, None] < (m_per_rank * (rank_idx + 1))
+            offs_bn = block_id_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+            msk_n = offs_bn[None, :] < N
+            for block_id_k in range(0, num_k_blocks):
+                offs_k = tl.arange(0, BLOCK_SIZE_K) + block_id_k * BLOCK_SIZE_K
+                a_ptrs = a_ptr + (
+                    matmul_offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak
+                )
+                b_ptrs = b_ptr + (
+                    offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn
+                )
+                a = tl.load(
+                    a_ptrs, mask=(offs_k[None, :] < K) & matmul_msk_am, other=0.0
+                )
+                b = tl.load(b_ptrs, mask=(offs_k[:, None] < K) & msk_n, other=0.0)
+                # We accumulate along the K dimension.
+                accumulator += tl.dot(a, b)
+            c = accumulator
+            # -----------------------------------------------------------
+            # Write the block of the output matrix C with masks.
+            offs_peer_mem_m = (
+                buffer_id * buffer_row_size
+                + block_id * BLOCK_SIZE_M
+                + tl.arange(0, BLOCK_SIZE_M)
+            )
+            offs_peer_mem_n = tl.arange(0, BLOCK_SIZE_N)
+            peer_mem_ptrs = (
+                peer_mem_ptr
+                + BLOCK_SIZE_N * offs_peer_mem_m[:, None]
+                + offs_peer_mem_n[None, :]
+            )
+            tl.store(peer_mem_ptrs, c)
+        libshmem_device.barrier_all()
+        comm_problem_size_m_per_rank = tl.cdiv(
+            actual_loop_num_per_comm * BLOCK_SIZE_M, rank_size
+        )
+        comm_block_num_per_rank = tl.cdiv(
+            comm_problem_size_m_per_rank, COMM_BLOCK_SIZE_M
+        ) * tl.cdiv(BLOCK_SIZE_N, COMM_BLOCK_SIZE_N)
+        if subblock_idx == 0:
+            for idx in range(pid, comm_block_num_per_rank * rank_size, ncore):
+                block_id_m, block_id_n, target_rank, comm_row_shape, comm_col_shape = (
+                    dist_swizzle2d_Nz(
+                        idx,
+                        rank_size,
+                        comm_problem_size_m_per_rank,
+                        BLOCK_SIZE_N,
+                        COMM_BLOCK_SIZE_M,
+                        COMM_BLOCK_SIZE_N,
+                    )
+                )
+                remote_ptr = dl.symm_at(peer_mem_ptr, target_rank)
+                comm_offs_m = (
+                    tl.arange(0, COMM_BLOCK_SIZE_M)
+                    + block_id_m * COMM_BLOCK_SIZE_M
+                    + rank * comm_problem_size_m_per_rank
+                    + buffer_id * loop_num_per_comm * BLOCK_SIZE_M
+                )
+                comm_offs_n = (
+                    tl.arange(0, COMM_BLOCK_SIZE_N) + block_id_n * COMM_BLOCK_SIZE_N
+                )
+                remote_ptrs = remote_ptr + (
+                    comm_offs_m[:, None] * BLOCK_SIZE_N + comm_offs_n[None, :]
+                )
+                block_id = block_id_m * COMM_BLOCK_SIZE_M // BLOCK_SIZE_M
+                block_id_in_rank = output_block_offset_in_rank + block_id
+                block_id_gemm_m, block_id_gemm_n = gemm_swizzle2d_Nz(
+                    block_id_in_rank, m_per_rank, N, BLOCK_SIZE_M, BLOCK_SIZE_N
+                )
+                m_offset_in_block = (block_id_m * COMM_BLOCK_SIZE_M) % BLOCK_SIZE_M
+                n_offset_in_block = (block_id_n * COMM_BLOCK_SIZE_N) % BLOCK_SIZE_N
+                offs_cm = (
+                    block_id_gemm_m * BLOCK_SIZE_M
+                    + m_offset_in_block
+                    + tl.arange(0, COMM_BLOCK_SIZE_M)
+                )
+                offs_cn = (
+                    block_id_gemm_n * BLOCK_SIZE_N
+                    + n_offset_in_block
+                    + tl.arange(0, COMM_BLOCK_SIZE_N)
+                )
+                c_offs = stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
+                c_mask = (offs_cm[:, None] < m_per_rank) & (offs_cn[None, :] < N)
+                c_temp = tl.load(remote_ptrs)
+                tl.atomic_add(c_ptr + c_offs, c_temp, mask=c_mask)
+
+
+def gemm_reduce_scatter(
+    A,
+    B,
+    C,
+    peer_mem,
+    rank,
+    rank_size,
+    buffer_num,
+    pvalue,
+    BLOCK_SIZE_M,
+    BLOCK_SIZE_N,
+    BLOCK_SIZE_K,
+    COMM_BLOCK_SIZE_M,
+    COMM_BLOCK_SIZE_N,
+):
+    """consume gemm"""
+    M, K = A.shape
+    _, N = B.shape
+    ncore = 20
+    assert ncore <= 20, "block num should less than or equal physical aicore num"
+    kernel_gemm_reduce_scatter[ncore, 1, 1](
+        A,
+        B,
+        C,
+        peer_mem,
+        rank,
+        rank_size,
+        buffer_num,
+        M,
+        N,
+        K,
+        A.stride(0),
+        A.stride(1),
+        B.stride(0),
+        B.stride(1),
+        C.stride(0),
+        C.stride(1),
+        pvalue,
+        BLOCK_SIZE_M,
+        BLOCK_SIZE_N,
+        BLOCK_SIZE_K,
+        COMM_BLOCK_SIZE_M,
+        COMM_BLOCK_SIZE_N,
+    )
+
+
+def torch_gemm_reduce_scatter(A_list, B_list, rank, world_size):
+    """
+    torch reduce-scatter gemm using torch.distributed.all_gather
+    - A_list: list of A tensors from all ranks (gathered)
+    - B_list: list of B tensors from all ranks (gathered)
+    - rank: current rank
+    - world_size: number of ranks
+    Returns: C_golden for this rank (1/world_size of total)
+    """
+    # Compute local C_i = A_i @ B_i for each rank
+    C_list = [
+        torch.matmul(A_list[i].to(torch.float32), B_list[i].to(torch.float32))
+        for i in range(world_size)
+    ]
+
+    # Sum all C tensors across all ranks
+    C_sum = sum(C_list)
+
+    # Each rank gets 1/world_size of the result (M // world_size rows)
+    m_per_rank = C_sum.shape[0] // world_size
+    start_idx = rank * m_per_rank
+    end_idx = start_idx + m_per_rank
+
+    return C_sum[start_idx:end_idx].to(torch.float16)
+
+
+def run_test_distributed():
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 256
+    COMM_BLOCK_SIZE_M = 8
+    COMM_BLOCK_SIZE_N = 256
+    buffer_num = 2
+    pvalue = 4
+    ncore = 20
+    pe = dist.get_rank()
+    world_size = dist.get_world_size()
+    ret = ash.set_conf_store_tls(False, "")
+    if ret != 0:
+        raise ValueError("[ERROR] set_conf_store_tls failed")
+    attributes = ash.InitAttr()
+    attributes.my_rank = pe
+    attributes.n_ranks = world_size
+    attributes.local_mem_size = g_ash_size
+    attributes.ip_port = G_IP_PORT
+    attributes.option_attr.data_op_engine_type = ash.OpEngineType.MTE
+    ret = ash.aclshmem_init(attributes)
+    if ret != 0:
+        raise ValueError("[ERROR] aclshmem_init failed")
+
+    # Calculate peer_mem size based on world_size
+    peer_mem_size = BLOCK_SIZE_M * pvalue * ncore * buffer_num * BLOCK_SIZE_N
+    peer_mem = ash.aclshmem_create_tensor(
+        [peer_mem_size],
+        dtype=torch.float32,
+        device_id=pe,
+    )
+
+    # Each rank creates its own local A and B tensors
+    A_local = torch.randn([M, K], dtype=dtype).npu()
+    B_local = torch.randn([K, N], dtype=dtype).npu()
+    C = torch.zeros([M // world_size, N], dtype=torch.float32).npu()
+
+    # Gather all A and B tensors from all ranks
+    A_list = [torch.empty_like(A_local) for _ in range(world_size)]
+    B_list = [torch.empty_like(B_local) for _ in range(world_size)]
+    dist.all_gather(A_list, A_local)
+    dist.all_gather(B_list, B_local)
+
+    # Compute golden reference using reduce-scatter
+    C_golden = torch_gemm_reduce_scatter(A_list, B_list, pe, world_size)
+
+    # Run the distributed kernel with local A and B
+    gemm_reduce_scatter(
+        A_local,
+        B_local,
+        C,
+        peer_mem,
+        pe,
+        world_size,
+        buffer_num,
+        pvalue,
+        BLOCK_SIZE_M,
+        BLOCK_SIZE_N,
+        BLOCK_SIZE_K,
+        COMM_BLOCK_SIZE_M,
+        COMM_BLOCK_SIZE_N,
+    )
+
+    passed = torch.tensor([1], dtype=torch.int32).npu()
+    error_msg = ""
+    try:
+        torch.testing.assert_close(C_golden, C.to(torch.float16), rtol=1e-3, atol=1e-3)
+    except AssertionError as e:
+        passed[0] = 0
+        error_msg = str(e)
+        raise
+
+    # Gather all ranks' pass/fail status
+    all_passed = [torch.zeros(1, dtype=torch.int32).npu() for _ in range(world_size)]
+    dist.all_gather(all_passed, passed)
+
+    # Print sequentially, one rank at a time
+    dist.barrier()
+    for rank_id in range(world_size):
+        if pe == rank_id:
+            if all_passed[rank_id].item() == 1:
+                print(
+                    f"{GREEN}[PASS]{RESET} Rank {pe}: C_golden and C match within tolerances (rtol=1e-3, atol=1e-3).",
+                    flush=True,
+                )
+            else:
+                print(
+                    f"{RED}[FAIL]{RESET} Rank {pe}: C_golden and C do NOT match. Details:\n{error_msg}",
+                    flush=True,
+                )
+        dist.barrier()
+    # Raise if any rank failed
+    if any(r.item() == 0 for r in all_passed):
+        if passed.item() == 0:
+            raise AssertionError(error_msg)
+
+    ash.aclshmem_free_tensor(peer_mem)
+    _ = ash.aclshmem_finialize()
+
+
+if __name__ == "__main__":
+    local_pe = int(os.environ["LOCAL_RANK"])
+    torch.npu.set_device(local_pe)
+    dist.init_process_group(backend="hccl", rank=local_pe)
+    dtype, M, N, K = [torch.float16, 4096, 4096, 4096]
+    world_size = dist.get_world_size()
+
+    print(f"[INFO] Rank {local_pe} of {world_size} initialized")
+    dist.barrier()
+    run_test_distributed()
+    if local_pe == 0:
+        print(f"[INFO] Test passed successfully for {world_size} ranks!")

--- a/tutorials/13-ascend-gemm-allreduce-oneshot.py
+++ b/tutorials/13-ascend-gemm-allreduce-oneshot.py
@@ -1,0 +1,383 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+import os
+import torch
+import torch_npu
+import shmem as ash
+import torch.distributed as dist
+import triton
+import triton.language as tl
+import triton_dist.language as dl
+from triton_dist.language.extra import libshmem_device
+from triton_dist.language.extra.ascend.algorithm import (
+    dist_swizzle2d_Nz,
+    gemm_swizzle2d_Nz,
+)
+from triton.language.extra.cann.extension import sub_vec_id
+import numpy as np
+
+g_ash_size = 1024 * 1024 * 1024
+g_malloc_size = 8 * 1024 * 1024
+G_IP_PORT = "tcp://127.0.0.1:8666"
+
+# ANSI color codes
+GREEN = "\033[92m"
+RED = "\033[91m"
+RESET = "\033[0m"
+BOLD = "\033[1m"
+
+
+@triton.jit
+def kernel_gemm_allreduce(
+    # Pointers to matrices
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    peer_mem_ptr,
+    # Distributed parameters
+    rank,
+    rank_size,
+    buffer_num,
+    # Matrix dimensions
+    M,
+    N,
+    K,
+    # The stride variables represent how much to increase the ptr by when moving by 1
+    # element in a particular dimension. E.g. `stride_am` is how much to increase `a_ptr`
+    # by to get the element one row down (A has M rows).
+    stride_am,
+    stride_ak,  #
+    stride_bk,
+    stride_bn,  #
+    stride_cm,
+    stride_cn,
+    # Meta-parameters
+    pvalue: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    COMM_BLOCK_SIZE_M: tl.constexpr,
+    COMM_BLOCK_SIZE_N: tl.constexpr,
+):
+    """Kernel for computing the matmul C = A x B.
+    A has shape (M, K), B has shape (K, N) and C has shape (M, N)
+    """
+    subblock_idx = sub_vec_id()
+    ncore = tl.num_programs(axis=0)
+    pid = tl.program_id(axis=0)
+    loop_num_per_comm = ncore * pvalue
+    num_loops_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_loops_n = tl.cdiv(N, BLOCK_SIZE_N)
+    total_loops = num_loops_m * num_loops_n
+    num_loops_comm = tl.cdiv(total_loops, loop_num_per_comm)
+    buffer_row_size = BLOCK_SIZE_M * loop_num_per_comm
+    for global_id in range(0, num_loops_comm):
+        buffer_id = global_id % buffer_num
+        actual_loop_num_per_comm = loop_num_per_comm
+        output_block_id_offset = global_id * loop_num_per_comm
+        # process tail block
+        if global_id == num_loops_comm - 1:
+            actual_loop_num_per_comm = total_loops - global_id * loop_num_per_comm
+        num_k_blocks = tl.cdiv(K, BLOCK_SIZE_K)
+        for block_id in range(pid, actual_loop_num_per_comm, ncore):
+            block_id_m, block_id_n = gemm_swizzle2d_Nz(
+                output_block_id_offset + block_id,
+                M,
+                N,
+                BLOCK_SIZE_M,
+                BLOCK_SIZE_N,
+            )
+            accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+            matmul_offs_am = block_id_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+            matmul_msk_am = matmul_offs_am[:, None] < M
+            offs_bn = block_id_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+            msk_n = offs_bn[None, :] < N
+            for block_id_k in range(0, num_k_blocks):
+                offs_k = tl.arange(0, BLOCK_SIZE_K) + block_id_k * BLOCK_SIZE_K
+                a_ptrs = a_ptr + (
+                    matmul_offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak
+                )
+                b_ptrs = b_ptr + (
+                    offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn
+                )
+                a = tl.load(
+                    a_ptrs, mask=(offs_k[None, :] < K) & matmul_msk_am, other=0.0
+                )
+                b = tl.load(b_ptrs, mask=(offs_k[:, None] < K) & msk_n, other=0.0)
+                # We accumulate along the K dimension.
+                accumulator += tl.dot(a, b)
+            c = accumulator
+            # -----------------------------------------------------------
+            # Write the block of the output matrix C with masks.
+            offs_peer_mem_m = (
+                buffer_id * buffer_row_size
+                + block_id * BLOCK_SIZE_M
+                + tl.arange(0, BLOCK_SIZE_M)
+            )
+            offs_peer_mem_n = tl.arange(0, BLOCK_SIZE_N)
+            peer_mem_ptrs = (
+                peer_mem_ptr
+                + BLOCK_SIZE_N * offs_peer_mem_m[:, None]
+                + offs_peer_mem_n[None, :]
+            )
+            tl.store(peer_mem_ptrs, c)
+        libshmem_device.barrier_all()
+        comm_problem_size_m = actual_loop_num_per_comm * BLOCK_SIZE_M
+        comm_block_num = tl.cdiv(comm_problem_size_m, COMM_BLOCK_SIZE_M) * tl.cdiv(
+            BLOCK_SIZE_N, COMM_BLOCK_SIZE_N
+        )
+        if subblock_idx == 0:
+            for idx in range(pid, comm_block_num * rank_size, ncore):
+                block_id_m, block_id_n, target_rank, comm_row_shape, comm_col_shape = (
+                    dist_swizzle2d_Nz(
+                        idx,
+                        rank_size,
+                        comm_problem_size_m,
+                        BLOCK_SIZE_N,
+                        COMM_BLOCK_SIZE_M,
+                        COMM_BLOCK_SIZE_N,
+                    )
+                )
+                remote_ptr = dl.symm_at(peer_mem_ptr, target_rank)
+                comm_offs_m = (
+                    tl.arange(0, COMM_BLOCK_SIZE_M)
+                    + block_id_m * COMM_BLOCK_SIZE_M
+                    + buffer_id * loop_num_per_comm * BLOCK_SIZE_M
+                )
+                comm_offs_n = (
+                    tl.arange(0, COMM_BLOCK_SIZE_N) + block_id_n * COMM_BLOCK_SIZE_N
+                )
+                remote_ptrs = remote_ptr + (
+                    comm_offs_m[:, None] * BLOCK_SIZE_N + comm_offs_n[None, :]
+                )
+                block_id = block_id_m * COMM_BLOCK_SIZE_M // BLOCK_SIZE_M
+                block_id_gemm_m, block_id_gemm_n = gemm_swizzle2d_Nz(
+                    output_block_id_offset + block_id, M, N, BLOCK_SIZE_M, BLOCK_SIZE_N
+                )
+                m_offset_in_block = (block_id_m * COMM_BLOCK_SIZE_M) % BLOCK_SIZE_M
+                n_offset_in_block = (block_id_n * COMM_BLOCK_SIZE_N) % BLOCK_SIZE_N
+                offs_cm = (
+                    block_id_gemm_m * BLOCK_SIZE_M
+                    + m_offset_in_block
+                    + tl.arange(0, COMM_BLOCK_SIZE_M)
+                )
+                offs_cn = (
+                    block_id_gemm_n * BLOCK_SIZE_N
+                    + n_offset_in_block
+                    + tl.arange(0, COMM_BLOCK_SIZE_N)
+                )
+                c_offs = stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
+                c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+                c_temp = tl.load(remote_ptrs)
+                tl.atomic_add(c_ptr + c_offs, c_temp, mask=c_mask)
+
+
+def gemm_allreduce(
+    A,
+    B,
+    C,
+    peer_mem,
+    rank,
+    rank_size,
+    buffer_num,
+    pvalue,
+    BLOCK_SIZE_M,
+    BLOCK_SIZE_N,
+    BLOCK_SIZE_K,
+    COMM_BLOCK_SIZE_M,
+    COMM_BLOCK_SIZE_N,
+):
+    """consume gemm"""
+    M, K = A.shape
+    _, N = B.shape
+    ncore = 20
+    assert ncore <= 20, "block num should less than or equal physical aicore num"
+    kernel_gemm_allreduce[ncore, 1, 1](
+        A,
+        B,
+        C,
+        peer_mem,
+        rank,
+        rank_size,
+        buffer_num,
+        M,
+        N,
+        K,
+        A.stride(0),
+        A.stride(1),
+        B.stride(0),
+        B.stride(1),
+        C.stride(0),
+        C.stride(1),
+        pvalue,
+        BLOCK_SIZE_M,
+        BLOCK_SIZE_N,
+        BLOCK_SIZE_K,
+        COMM_BLOCK_SIZE_M,
+        COMM_BLOCK_SIZE_N,
+    )
+
+
+def torch_gemm_allreduce(A_list, B_list, world_size):
+    """
+    Compute golden reference using PyTorch's matmul and all_reduce.
+
+    Args:
+        A_list: List of A matrices from all ranks (each on their respective device)
+        B_list: List of B matrices from all ranks (each on their respective device)
+        world_size: Number of ranks
+
+    Returns:
+        C_golden: The all-reduced result (C = sum(A_i @ B_i) for all ranks i)
+    """
+    # Get local rank
+    rank = dist.get_rank()
+
+    # Compute local C = A @ B
+    A_rank = A_list[rank]
+    B_rank = B_list[rank]
+    C_local = torch.matmul(A_rank.to(torch.float32), B_rank.to(torch.float32))
+
+    # Use torch.distributed.all_reduce to get the golden reference
+    C_golden = C_local.clone()
+    dist.all_reduce(C_golden, op=dist.ReduceOp.SUM)
+
+    return C_golden.to(torch.float16)
+
+
+def generate_matrices_for_rank(rank, M, N, K, dtype, seed_base=42):
+    """
+    Generate consistent A and B matrices for a given rank using a seed.
+
+    Args:
+        rank: Rank ID
+        M, N, K: Matrix dimensions
+        dtype: Data type
+        seed_base: Base seed for reproducibility
+
+    Returns:
+        A: Matrix of shape (M, K)
+        B: Matrix of shape (K, N)
+    """
+    # Use rank-specific seed for reproducibility
+    torch.manual_seed(seed_base + rank)
+    A = torch.randn([M, K], dtype=dtype)
+    B = torch.randn([K, N], dtype=dtype)
+    return A, B
+
+
+def run_test_distributed():
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 256
+    COMM_BLOCK_SIZE_M = 8
+    COMM_BLOCK_SIZE_N = 256
+    buffer_num = 2
+    pvalue = 4
+    ncore = 20
+    pe = dist.get_rank()
+    world_size = dist.get_world_size()
+    ret = ash.set_conf_store_tls(False, "")
+    if ret != 0:
+        raise ValueError("[ERROR] set_conf_store_tls failed")
+    attributes = ash.InitAttr()
+    attributes.my_rank = pe
+    attributes.n_ranks = world_size
+    attributes.local_mem_size = g_ash_size
+    attributes.ip_port = G_IP_PORT
+    attributes.option_attr.data_op_engine_type = ash.OpEngineType.MTE
+    ret = ash.aclshmem_init(attributes)
+    if ret != 0:
+        raise ValueError("[ERROR] aclshmem_init failed")
+
+    # Calculate peer_mem size based on world_size (supports any number of ranks)
+    peer_mem_size = (
+        BLOCK_SIZE_M * pvalue * ncore * buffer_num * BLOCK_SIZE_N * world_size
+    )
+    peer_mem = ash.aclshmem_create_tensor(
+        [peer_mem_size],
+        dtype=torch.float32,
+        device_id=pe,
+    )
+    C = torch.zeros([M, N], dtype=torch.float32).npu()
+
+    # Generate A and B matrices for all ranks using seeds
+    A_list = []
+    B_list = []
+    for i in range(world_size):
+        A_i, B_i = generate_matrices_for_rank(i, M, N, K, dtype)
+        A_list.append(A_i.npu())
+        B_list.append(B_i.npu())
+
+    # Extract local matrices
+    A_rank = A_list[pe]
+    B_rank = B_list[pe]
+
+    # Compute golden reference using torch_gemm_allreduce
+    C_golden = torch_gemm_allreduce(A_list, B_list, world_size)
+
+    gemm_allreduce(
+        A_rank,
+        B_rank,
+        C,
+        peer_mem,
+        pe,
+        world_size,
+        buffer_num,
+        pvalue,
+        BLOCK_SIZE_M,
+        BLOCK_SIZE_N,
+        BLOCK_SIZE_K,
+        COMM_BLOCK_SIZE_M,
+        COMM_BLOCK_SIZE_N,
+    )
+
+    passed = torch.tensor([1], dtype=torch.int32).npu()
+    error_msg = ""
+    try:
+        torch.testing.assert_close(C_golden, C.to(torch.float16), rtol=1e-3, atol=1e-3)
+    except AssertionError as e:
+        passed[0] = 0
+        error_msg = str(e)
+        raise
+
+    # Gather all ranks' pass/fail status
+    all_passed = [torch.zeros(1, dtype=torch.int32).npu() for _ in range(world_size)]
+    dist.all_gather(all_passed, passed)
+
+    # Print sequentially, one rank at a time
+    dist.barrier()
+    for rank_id in range(world_size):
+        if pe == rank_id:
+            if all_passed[rank_id].item() == 1:
+                print(
+                    f"{GREEN}[PASS]{RESET} Rank {pe}: C_golden and C match within tolerances (rtol=1e-3, atol=1e-3).",
+                    flush=True,
+                )
+            else:
+                print(
+                    f"{RED}[FAIL]{RESET} Rank {pe}: C_golden and C do NOT match. Details:\n{error_msg}",
+                    flush=True,
+                )
+        dist.barrier()
+    # Raise if any rank failed
+    if any(r.item() == 0 for r in all_passed):
+        if passed.item() == 0:
+            raise AssertionError(error_msg)
+
+    ash.aclshmem_free_tensor(peer_mem)
+    _ = ash.aclshmem_finialize()
+
+
+if __name__ == "__main__":
+    local_pe = int(os.environ["LOCAL_RANK"])
+    torch.npu.set_device(local_pe)
+    dist.init_process_group(backend="hccl", rank=local_pe)
+    dtype, M, N, K = [torch.float16, 4096, 4096, 4096]
+    world_size = dist.get_world_size()
+
+    print(f"[INFO] Rank {local_pe} of {world_size} initialized")
+    dist.barrier()
+    run_test_distributed()
+    if local_pe == 0:
+        print(f"[INFO] Test passed successfully for {world_size} ranks!")

--- a/tutorials/ascend/01-ascend-allgather-gemm.py
+++ b/tutorials/ascend/01-ascend-allgather-gemm.py
@@ -1,0 +1,350 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+import os
+import torch
+import torch_npu
+import shmem as ash
+import torch.distributed as dist
+import triton
+import triton.language as tl
+import triton_dist.language as dl
+from triton_dist.language.extra import libshmem_device
+from triton_dist.language.extra.ascend.algorithm import (
+    dist_swizzle2d_Nz,
+    gemm_swizzle2d_Nz,
+)
+from triton.language.extra.cann.extension import sub_vec_id
+import numpy as np
+
+g_ash_size = 1024 * 1024 * 1024
+g_malloc_size = 8 * 1024 * 1024
+G_IP_PORT = "tcp://127.0.0.1:8666"
+
+# ANSI color codes
+GREEN = "\033[92m"
+RED = "\033[91m"
+RESET = "\033[0m"
+BOLD = "\033[1m"
+
+
+@triton.jit
+def kernel_allgather_gemm(
+    # Pointers to matrices
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    peer_mem_ptr,
+    # Distributed parameters
+    rank,
+    rank_size,
+    buffer_num,
+    # Matrix dimensions
+    M,
+    N,
+    K,
+    # The stride variables represent how much to increase the ptr by when moving by 1
+    # element in a particular dimension. E.g. `stride_am` is how much to increase `a_ptr`
+    # by to get the element one row down (A has M rows).
+    stride_am,
+    stride_ak,  #
+    stride_bk,
+    stride_bn,  #
+    stride_cm,
+    stride_cn,
+    # Meta-parameters
+    pvalue: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    COMM_BLOCK_SIZE_M: tl.constexpr,
+    COMM_BLOCK_SIZE_K: tl.constexpr,
+):
+    """Kernel for computing the matmul C = A x B.
+    A has shape (M, K), B has shape (K, N) and C has shape (M, N)
+    """
+    dtype = tl.float16
+    subblock_idx = sub_vec_id()
+    ncore = tl.num_programs(axis=0)
+    pid = tl.program_id(axis=0)
+    num_loops_m = tl.cdiv(M, BLOCK_SIZE_M * pvalue)
+    num_loops_n = tl.cdiv(N, BLOCK_SIZE_N)
+    buffer_row_size = BLOCK_SIZE_M * pvalue * rank_size
+    for global_id_m in range(0, num_loops_m):
+        buffer_id = global_id_m % buffer_num
+        actual_block_size_m = BLOCK_SIZE_M * pvalue
+        # process tail block
+        if global_id_m == num_loops_m - 1:
+            actual_block_size_m = M - global_id_m * BLOCK_SIZE_M * pvalue
+        num_k_blocks = tl.cdiv(K, BLOCK_SIZE_K)
+        comm_num_m_blocks = tl.cdiv(actual_block_size_m, COMM_BLOCK_SIZE_M)
+        comm_num_k_blocks = tl.cdiv(K, COMM_BLOCK_SIZE_K)
+        if subblock_idx == 0:
+            for k in range(pid,
+                           comm_num_m_blocks * comm_num_k_blocks * rank_size,
+                           ncore):
+                block_id_m, block_id_k, target_rank, comm_row_shape, comm_col_shape = (
+                    dist_swizzle2d_Nz(
+                        k,
+                        rank_size,
+                        actual_block_size_m,
+                        K,
+                        COMM_BLOCK_SIZE_M,
+                        COMM_BLOCK_SIZE_K,
+                    ))
+                remote_ptr = dl.symm_at(peer_mem_ptr, target_rank)
+                comm_offs_m = (tl.arange(0, COMM_BLOCK_SIZE_M) +
+                               block_id_m * COMM_BLOCK_SIZE_M +
+                               global_id_m * BLOCK_SIZE_M * pvalue)
+                comm_offs_k = (tl.arange(0, COMM_BLOCK_SIZE_K) +
+                               block_id_k * COMM_BLOCK_SIZE_K)
+                a_ptrs = a_ptr + (comm_offs_m[:, None] * stride_am +
+                                  comm_offs_k[None, :] * stride_ak)
+                peermem_comm_offs_m = (buffer_id * buffer_row_size +
+                                       rank * BLOCK_SIZE_M * pvalue +
+                                       block_id_m * COMM_BLOCK_SIZE_M +
+                                       tl.arange(0, COMM_BLOCK_SIZE_M))
+                remote_ptrs = remote_ptr + (
+                    peermem_comm_offs_m[:, None] * stride_am +
+                    comm_offs_k[None, :] * stride_ak)
+                comm_msk_m = comm_offs_m[:, None] < M
+                peermem_comm_msk_m = (peermem_comm_offs_m[:, None]
+                                      < buffer_id * buffer_row_size +
+                                      BLOCK_SIZE_M * rank * pvalue +
+                                      block_id_m * COMM_BLOCK_SIZE_M +
+                                      comm_row_shape)
+                a = tl.load(a_ptrs,
+                            mask=(comm_offs_k[None, :] < K) & comm_msk_m,
+                            other=0.0)
+                tl.store(remote_ptrs,
+                         a,
+                         mask=(comm_offs_k[None, :] < K) & peermem_comm_msk_m)
+        libshmem_device.barrier_all()
+        num_tiles_m = tl.cdiv(actual_block_size_m, BLOCK_SIZE_M)
+        for block_id in range(pid, num_tiles_m * num_loops_n * rank_size,
+                              ncore):
+            block_id_m, block_id_n = gemm_swizzle2d_Nz(
+                block_id,
+                rank_size * BLOCK_SIZE_M * num_tiles_m,
+                N,
+                BLOCK_SIZE_M,
+                BLOCK_SIZE_N,
+            )
+            rank_idx = block_id_m // num_tiles_m
+            block_id_m = rank_idx * pvalue + (block_id_m % num_tiles_m)
+            accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N),
+                                   dtype=tl.float32)
+            matmul_offs_am = (buffer_id * buffer_row_size +
+                              block_id_m * BLOCK_SIZE_M +
+                              tl.arange(0, BLOCK_SIZE_M))
+            matmul_msk_am = matmul_offs_am[:, None] < (
+                buffer_id * buffer_row_size +
+                BLOCK_SIZE_M * rank_idx * pvalue + actual_block_size_m)
+            offs_bn = block_id_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+            msk_n = offs_bn[None, :] < N
+            for block_id_k in range(0, num_k_blocks):
+                offs_k = tl.arange(0, BLOCK_SIZE_K) + block_id_k * BLOCK_SIZE_K
+                a_ptrs = peer_mem_ptr + (matmul_offs_am[:, None] * stride_am +
+                                         offs_k[None, :] * stride_ak)
+                b_ptrs = b_ptr + (offs_k[:, None] * stride_bk +
+                                  offs_bn[None, :] * stride_bn)
+                a = tl.load(a_ptrs,
+                            mask=(offs_k[None, :] < K) & matmul_msk_am,
+                            other=0.0)
+                b = tl.load(b_ptrs,
+                            mask=(offs_k[:, None] < K) & msk_n,
+                            other=0.0)
+                # We accumulate along the K dimension.
+                accumulator += tl.dot(a, b)
+            c = accumulator.to(dtype)
+            # -----------------------------------------------------------
+            # Write back the block of the output matrix C with masks.
+            offs_cm = (block_id_m // pvalue * M +
+                       global_id_m * BLOCK_SIZE_M * pvalue +
+                       (block_id_m % pvalue) * BLOCK_SIZE_M +
+                       tl.arange(0, BLOCK_SIZE_M))
+            offs_cn = block_id_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+            c_ptrs = c_ptr + stride_cm * offs_cm[:,
+                                                 None] + stride_cn * offs_cn[
+                                                     None, :]
+            c_mask = (offs_cm[:, None] < M *
+                      (block_id_m // pvalue + 1)) & (offs_cn[None, :] < N)
+            tl.store(c_ptrs, c, mask=c_mask)
+
+
+def allgather_gemm(
+    A,
+    B,
+    C,
+    peer_mem,
+    rank,
+    rank_size,
+    buffer_num,
+    pvalue,
+    BLOCK_SIZE_M,
+    BLOCK_SIZE_N,
+    BLOCK_SIZE_K,
+    COMM_BLOCK_SIZE_M,
+    COMM_BLOCK_SIZE_K,
+):
+    """consume gemm"""
+    M, K = A.shape
+    _, N = B.shape
+    ncore = 20
+    assert ncore <= 20, "block num should less than or equal physical aicore num"
+    kernel_allgather_gemm[ncore, 1, 1](
+        A,
+        B,
+        C,
+        peer_mem,
+        rank,
+        rank_size,
+        buffer_num,
+        M,
+        N,
+        K,
+        A.stride(0),
+        A.stride(1),
+        B.stride(0),
+        B.stride(1),
+        C.stride(0),
+        C.stride(1),
+        pvalue,
+        BLOCK_SIZE_M,
+        BLOCK_SIZE_N,
+        BLOCK_SIZE_K,
+        COMM_BLOCK_SIZE_M,
+        COMM_BLOCK_SIZE_K,
+    )
+
+
+def torch_allgather_gemm(A_local, B, world_size):
+    """
+    torch allgather gemm using torch.distributed.all_gather
+    - A_local: local A tensor on this rank
+    - B: B tensor (same across all ranks)
+    - world_size: number of ranks
+    Returns: C_golden computed from all-gathered A tensors
+    """
+    # Create a list to hold gathered A tensors from all ranks
+    A_list = [torch.empty_like(A_local) for _ in range(world_size)]
+
+    # Gather all A tensors from all ranks
+    dist.all_gather(A_list, A_local)
+
+    # Concatenate all A tensors along the first dimension
+    A_golden = torch.cat(A_list, dim=0)
+
+    # Compute golden reference: C = A_golden @ B
+
+    C_golden = torch.matmul(A_golden, B)
+    return C_golden
+
+
+def run_test_distributed():
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 256
+    COMM_BLOCK_SIZE_M = 20
+    COMM_BLOCK_SIZE_K = 256
+    buffer_num = 2
+    pvalue = 4
+    pe = dist.get_rank()
+    world_size = dist.get_world_size()
+    ret = ash.set_conf_store_tls(False, "")
+    if ret != 0:
+        raise ValueError("[ERROR] set_conf_store_tls failed")
+    attributes = ash.InitAttr()
+    attributes.my_rank = pe
+    attributes.n_ranks = world_size
+    attributes.local_mem_size = g_ash_size
+    attributes.ip_port = G_IP_PORT
+    attributes.option_attr.data_op_engine_type = ash.OpEngineType.MTE
+    ret = ash.aclshmem_init(attributes)
+    if ret != 0:
+        raise ValueError("[ERROR] aclshmem_init failed")
+
+    # Calculate peer_mem size based on world_size
+    peer_mem_size = (BLOCK_SIZE_M * pvalue * world_size * buffer_num *
+                     max(K, BLOCK_SIZE_K))
+    peer_mem = ash.aclshmem_create_tensor(
+        [peer_mem_size],
+        dtype=dtype,
+        device_id=pe,
+    )
+
+    # Each rank creates its own local A and B tensors
+    A_local = torch.randn([M, K], dtype=dtype).npu()
+    B = torch.randn([K, N], dtype=dtype).npu()
+    C = torch.zeros([M * world_size, N], dtype=dtype).npu()
+
+    # Compute golden reference using torch.distributed.all_gather
+    C_golden = torch_allgather_gemm(A_local, B, world_size)
+
+    # Run the distributed kernel with local A
+    allgather_gemm(
+        A_local,
+        B,
+        C,
+        peer_mem,
+        pe,
+        world_size,
+        buffer_num,
+        pvalue,
+        BLOCK_SIZE_M,
+        BLOCK_SIZE_N,
+        BLOCK_SIZE_K,
+        COMM_BLOCK_SIZE_M,
+        COMM_BLOCK_SIZE_K,
+    )
+
+    passed = torch.tensor([1], dtype=torch.int32).npu()
+    error_msg = ""
+    try:
+        torch.testing.assert_close(C_golden, C, rtol=1e-3, atol=1e-3)
+    except AssertionError as e:
+        passed[0] = 0
+        error_msg = str(e)
+        raise
+
+    # Gather all ranks' pass/fail status
+    all_passed = [
+        torch.zeros(1, dtype=torch.int32).npu() for _ in range(world_size)
+    ]
+    dist.all_gather(all_passed, passed)
+
+    # Print sequentially, one rank at a time
+    dist.barrier()
+    for rank_id in range(world_size):
+        if pe == rank_id:
+            if all_passed[rank_id].item() == 1:
+                print(
+                    f"{GREEN}[PASS]{RESET} Rank {pe}: C_golden and C match within tolerances (rtol=1e-3, atol=1e-3).",
+                    flush=True,
+                )
+            else:
+                print(
+                    f"{RED}[FAIL]{RESET} Rank {pe}: C_golden and C do NOT match. Details:\n{error_msg}",
+                    flush=True,
+                )
+        dist.barrier()
+    # Raise if any rank failed
+    if any(r.item() == 0 for r in all_passed):
+        if passed.item() == 0:
+            raise AssertionError(error_msg)
+
+    ash.aclshmem_free_tensor(peer_mem)
+    _ = ash.aclshmem_finialize()
+
+
+if __name__ == "__main__":
+    local_pe = int(os.environ["LOCAL_RANK"])
+    torch.npu.set_device(local_pe)
+    dist.init_process_group(backend="hccl", rank=local_pe)
+    dtype, M, N, K = [torch.float16, 4096, 4096, 4096]
+    world_size = dist.get_world_size()
+
+    print(f"[INFO] Rank {local_pe} of {world_size} initialized")
+    dist.barrier()
+    run_test_distributed()
+    if local_pe == 0:
+        print(f"[INFO] Test passed successfully for {world_size} ranks!")

--- a/tutorials/ascend/02-ascend-gemm-reduce-scatter.py
+++ b/tutorials/ascend/02-ascend-gemm-reduce-scatter.py
@@ -1,0 +1,364 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+import os
+import torch
+import torch_npu
+import shmem as ash
+import torch.distributed as dist
+import triton
+import triton.language as tl
+import triton_dist.language as dl
+from triton_dist.language.extra import libshmem_device
+from triton_dist.language.extra.ascend.algorithm import (
+    dist_swizzle2d_Nz,
+    gemm_swizzle2d_Nz,
+)
+from triton.language.extra.cann.extension import sub_vec_id
+import numpy as np
+
+g_ash_size = 1024 * 1024 * 1024
+g_malloc_size = 8 * 1024 * 1024
+G_IP_PORT = "tcp://127.0.0.1:8666"
+
+# ANSI color codes
+GREEN = "\033[92m"
+RED = "\033[91m"
+RESET = "\033[0m"
+BOLD = "\033[1m"
+
+
+@triton.jit
+def kernel_gemm_reduce_scatter(
+    # Pointers to matrices
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    peer_mem_ptr,
+    # Distributed parameters
+    rank,
+    rank_size,
+    buffer_num,
+    # Matrix dimensions
+    M,
+    N,
+    K,
+    # The stride variables represent how much to increase the ptr by when moving by 1
+    # element in a particular dimension. E.g. `stride_am` is how much to increase `a_ptr`
+    # by to get the element one row down (A has M rows).
+    stride_am,
+    stride_ak,  #
+    stride_bk,
+    stride_bn,  #
+    stride_cm,
+    stride_cn,
+    # Meta-parameters
+    pvalue: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    COMM_BLOCK_SIZE_M: tl.constexpr,
+    COMM_BLOCK_SIZE_N: tl.constexpr,
+):
+    """Kernel for computing the matmul C = A x B.
+    A has shape (M, K), B has shape (K, N) and C has shape (M, N)
+    """
+    subblock_idx = sub_vec_id()
+    ncore = tl.num_programs(axis=0)
+    pid = tl.program_id(axis=0)
+    loop_num_per_comm = ncore * pvalue
+    m_per_rank = M // rank_size
+    num_loops_m = tl.cdiv(m_per_rank, BLOCK_SIZE_M) * rank_size
+    num_loops_n = tl.cdiv(N, BLOCK_SIZE_N)
+    total_loops = num_loops_m * num_loops_n
+    num_loops_comm = tl.cdiv(total_loops, loop_num_per_comm)
+    buffer_row_size = BLOCK_SIZE_M * loop_num_per_comm
+    for global_id in range(0, num_loops_comm):
+        buffer_id = global_id % buffer_num
+        actual_loop_num_per_comm = loop_num_per_comm
+        output_block_offset_in_rank = global_id * loop_num_per_comm // rank_size
+        # process tail block
+        if global_id == num_loops_comm - 1:
+            actual_loop_num_per_comm = total_loops - global_id * loop_num_per_comm
+        num_k_blocks = tl.cdiv(K, BLOCK_SIZE_K)
+        num_blocks_per_rank = actual_loop_num_per_comm // rank_size
+        for block_id in range(pid, actual_loop_num_per_comm, ncore):
+            block_id_in_rank = (output_block_offset_in_rank +
+                                block_id % num_blocks_per_rank)
+            block_id_m, block_id_n = gemm_swizzle2d_Nz(
+                block_id_in_rank,
+                m_per_rank,
+                N,
+                BLOCK_SIZE_M,
+                BLOCK_SIZE_N,
+            )
+            rank_idx = block_id // num_blocks_per_rank
+            accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N),
+                                   dtype=tl.float32)
+            matmul_offs_am = (m_per_rank * rank_idx +
+                              block_id_m * BLOCK_SIZE_M +
+                              tl.arange(0, BLOCK_SIZE_M))
+            matmul_msk_am = matmul_offs_am[:, None] < (m_per_rank *
+                                                       (rank_idx + 1))
+            offs_bn = block_id_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+            msk_n = offs_bn[None, :] < N
+            for block_id_k in range(0, num_k_blocks):
+                offs_k = tl.arange(0, BLOCK_SIZE_K) + block_id_k * BLOCK_SIZE_K
+                a_ptrs = a_ptr + (matmul_offs_am[:, None] * stride_am +
+                                  offs_k[None, :] * stride_ak)
+                b_ptrs = b_ptr + (offs_k[:, None] * stride_bk +
+                                  offs_bn[None, :] * stride_bn)
+                a = tl.load(a_ptrs,
+                            mask=(offs_k[None, :] < K) & matmul_msk_am,
+                            other=0.0)
+                b = tl.load(b_ptrs,
+                            mask=(offs_k[:, None] < K) & msk_n,
+                            other=0.0)
+                # We accumulate along the K dimension.
+                accumulator += tl.dot(a, b)
+            c = accumulator
+            # -----------------------------------------------------------
+            # Write the block of the output matrix C with masks.
+            offs_peer_mem_m = (buffer_id * buffer_row_size +
+                               block_id * BLOCK_SIZE_M +
+                               tl.arange(0, BLOCK_SIZE_M))
+            offs_peer_mem_n = tl.arange(0, BLOCK_SIZE_N)
+            peer_mem_ptrs = (peer_mem_ptr +
+                             BLOCK_SIZE_N * offs_peer_mem_m[:, None] +
+                             offs_peer_mem_n[None, :])
+            tl.store(peer_mem_ptrs, c)
+        libshmem_device.barrier_all()
+        comm_problem_size_m_per_rank = tl.cdiv(
+            actual_loop_num_per_comm * BLOCK_SIZE_M, rank_size)
+        comm_block_num_per_rank = tl.cdiv(comm_problem_size_m_per_rank,
+                                          COMM_BLOCK_SIZE_M) * tl.cdiv(
+                                              BLOCK_SIZE_N, COMM_BLOCK_SIZE_N)
+        if subblock_idx == 0:
+            for idx in range(pid, comm_block_num_per_rank * rank_size, ncore):
+                block_id_m, block_id_n, target_rank, comm_row_shape, comm_col_shape = (
+                    dist_swizzle2d_Nz(
+                        idx,
+                        rank_size,
+                        comm_problem_size_m_per_rank,
+                        BLOCK_SIZE_N,
+                        COMM_BLOCK_SIZE_M,
+                        COMM_BLOCK_SIZE_N,
+                    ))
+                remote_ptr = dl.symm_at(peer_mem_ptr, target_rank)
+                comm_offs_m = (tl.arange(0, COMM_BLOCK_SIZE_M) +
+                               block_id_m * COMM_BLOCK_SIZE_M +
+                               rank * comm_problem_size_m_per_rank +
+                               buffer_id * loop_num_per_comm * BLOCK_SIZE_M)
+                comm_offs_n = (tl.arange(0, COMM_BLOCK_SIZE_N) +
+                               block_id_n * COMM_BLOCK_SIZE_N)
+                remote_ptrs = remote_ptr + (
+                    comm_offs_m[:, None] * BLOCK_SIZE_N + comm_offs_n[None, :])
+                block_id = block_id_m * COMM_BLOCK_SIZE_M // BLOCK_SIZE_M
+                block_id_in_rank = output_block_offset_in_rank + block_id
+                block_id_gemm_m, block_id_gemm_n = gemm_swizzle2d_Nz(
+                    block_id_in_rank, m_per_rank, N, BLOCK_SIZE_M,
+                    BLOCK_SIZE_N)
+                m_offset_in_block = (block_id_m *
+                                     COMM_BLOCK_SIZE_M) % BLOCK_SIZE_M
+                n_offset_in_block = (block_id_n *
+                                     COMM_BLOCK_SIZE_N) % BLOCK_SIZE_N
+                offs_cm = (block_id_gemm_m * BLOCK_SIZE_M + m_offset_in_block +
+                           tl.arange(0, COMM_BLOCK_SIZE_M))
+                offs_cn = (block_id_gemm_n * BLOCK_SIZE_N + n_offset_in_block +
+                           tl.arange(0, COMM_BLOCK_SIZE_N))
+                c_offs = stride_cm * offs_cm[:, None] + stride_cn * offs_cn[
+                    None, :]
+                c_mask = (offs_cm[:, None] < m_per_rank) & (offs_cn[None, :]
+                                                            < N)
+                c_temp = tl.load(remote_ptrs)
+                tl.atomic_add(c_ptr + c_offs, c_temp, mask=c_mask)
+
+
+def gemm_reduce_scatter(
+    A,
+    B,
+    C,
+    peer_mem,
+    rank,
+    rank_size,
+    buffer_num,
+    pvalue,
+    BLOCK_SIZE_M,
+    BLOCK_SIZE_N,
+    BLOCK_SIZE_K,
+    COMM_BLOCK_SIZE_M,
+    COMM_BLOCK_SIZE_N,
+):
+    """consume gemm"""
+    M, K = A.shape
+    _, N = B.shape
+    ncore = 20
+    assert ncore <= 20, "block num should less than or equal physical aicore num"
+    kernel_gemm_reduce_scatter[ncore, 1, 1](
+        A,
+        B,
+        C,
+        peer_mem,
+        rank,
+        rank_size,
+        buffer_num,
+        M,
+        N,
+        K,
+        A.stride(0),
+        A.stride(1),
+        B.stride(0),
+        B.stride(1),
+        C.stride(0),
+        C.stride(1),
+        pvalue,
+        BLOCK_SIZE_M,
+        BLOCK_SIZE_N,
+        BLOCK_SIZE_K,
+        COMM_BLOCK_SIZE_M,
+        COMM_BLOCK_SIZE_N,
+    )
+
+
+def torch_gemm_reduce_scatter(A_list, B_list, rank, world_size):
+    """
+    torch reduce-scatter gemm using torch.distributed.all_gather
+    - A_list: list of A tensors from all ranks (gathered)
+    - B_list: list of B tensors from all ranks (gathered)
+    - rank: current rank
+    - world_size: number of ranks
+    Returns: C_golden for this rank (1/world_size of total)
+    """
+    # Compute local C_i = A_i @ B_i for each rank
+    C_list = [
+        torch.matmul(A_list[i].to(torch.float32), B_list[i].to(torch.float32))
+        for i in range(world_size)
+    ]
+
+    # Sum all C tensors across all ranks
+    C_sum = sum(C_list)
+
+    # Each rank gets 1/world_size of the result (M // world_size rows)
+    m_per_rank = C_sum.shape[0] // world_size
+    start_idx = rank * m_per_rank
+    end_idx = start_idx + m_per_rank
+
+    return C_sum[start_idx:end_idx].to(torch.float16)
+
+
+def run_test_distributed():
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 256
+    COMM_BLOCK_SIZE_M = 8
+    COMM_BLOCK_SIZE_N = 256
+    buffer_num = 2
+    pvalue = 4
+    ncore = 20
+    pe = dist.get_rank()
+    world_size = dist.get_world_size()
+    ret = ash.set_conf_store_tls(False, "")
+    if ret != 0:
+        raise ValueError("[ERROR] set_conf_store_tls failed")
+    attributes = ash.InitAttr()
+    attributes.my_rank = pe
+    attributes.n_ranks = world_size
+    attributes.local_mem_size = g_ash_size
+    attributes.ip_port = G_IP_PORT
+    attributes.option_attr.data_op_engine_type = ash.OpEngineType.MTE
+    ret = ash.aclshmem_init(attributes)
+    if ret != 0:
+        raise ValueError("[ERROR] aclshmem_init failed")
+
+    # Calculate peer_mem size based on world_size
+    peer_mem_size = BLOCK_SIZE_M * pvalue * ncore * buffer_num * BLOCK_SIZE_N
+    peer_mem = ash.aclshmem_create_tensor(
+        [peer_mem_size],
+        dtype=torch.float32,
+        device_id=pe,
+    )
+
+    # Each rank creates its own local A and B tensors
+    A_local = torch.randn([M, K], dtype=dtype).npu()
+    B_local = torch.randn([K, N], dtype=dtype).npu()
+    C = torch.zeros([M // world_size, N], dtype=torch.float32).npu()
+
+    # Gather all A and B tensors from all ranks
+    A_list = [torch.empty_like(A_local) for _ in range(world_size)]
+    B_list = [torch.empty_like(B_local) for _ in range(world_size)]
+    dist.all_gather(A_list, A_local)
+    dist.all_gather(B_list, B_local)
+
+    # Compute golden reference using reduce-scatter
+    C_golden = torch_gemm_reduce_scatter(A_list, B_list, pe, world_size)
+
+    # Run the distributed kernel with local A and B
+    gemm_reduce_scatter(
+        A_local,
+        B_local,
+        C,
+        peer_mem,
+        pe,
+        world_size,
+        buffer_num,
+        pvalue,
+        BLOCK_SIZE_M,
+        BLOCK_SIZE_N,
+        BLOCK_SIZE_K,
+        COMM_BLOCK_SIZE_M,
+        COMM_BLOCK_SIZE_N,
+    )
+
+    passed = torch.tensor([1], dtype=torch.int32).npu()
+    error_msg = ""
+    try:
+        torch.testing.assert_close(C_golden,
+                                   C.to(torch.float16),
+                                   rtol=1e-3,
+                                   atol=1e-3)
+    except AssertionError as e:
+        passed[0] = 0
+        error_msg = str(e)
+        raise
+
+    # Gather all ranks' pass/fail status
+    all_passed = [
+        torch.zeros(1, dtype=torch.int32).npu() for _ in range(world_size)
+    ]
+    dist.all_gather(all_passed, passed)
+
+    # Print sequentially, one rank at a time
+    dist.barrier()
+    for rank_id in range(world_size):
+        if pe == rank_id:
+            if all_passed[rank_id].item() == 1:
+                print(
+                    f"{GREEN}[PASS]{RESET} Rank {pe}: C_golden and C match within tolerances (rtol=1e-3, atol=1e-3).",
+                    flush=True,
+                )
+            else:
+                print(
+                    f"{RED}[FAIL]{RESET} Rank {pe}: C_golden and C do NOT match. Details:\n{error_msg}",
+                    flush=True,
+                )
+        dist.barrier()
+    # Raise if any rank failed
+    if any(r.item() == 0 for r in all_passed):
+        if passed.item() == 0:
+            raise AssertionError(error_msg)
+
+    ash.aclshmem_free_tensor(peer_mem)
+    _ = ash.aclshmem_finialize()
+
+
+if __name__ == "__main__":
+    local_pe = int(os.environ["LOCAL_RANK"])
+    torch.npu.set_device(local_pe)
+    dist.init_process_group(backend="hccl", rank=local_pe)
+    dtype, M, N, K = [torch.float16, 4096, 4096, 4096]
+    world_size = dist.get_world_size()
+
+    print(f"[INFO] Rank {local_pe} of {world_size} initialized")
+    dist.barrier()
+    run_test_distributed()
+    if local_pe == 0:
+        print(f"[INFO] Test passed successfully for {world_size} ranks!")

--- a/tutorials/ascend/03-ascend-gemm-allreduce-oneshot.py
+++ b/tutorials/ascend/03-ascend-gemm-allreduce-oneshot.py
@@ -1,0 +1,377 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+import os
+import torch
+import torch_npu
+import shmem as ash
+import torch.distributed as dist
+import triton
+import triton.language as tl
+import triton_dist.language as dl
+from triton_dist.language.extra import libshmem_device
+from triton_dist.language.extra.ascend.algorithm import (
+    dist_swizzle2d_Nz,
+    gemm_swizzle2d_Nz,
+)
+from triton.language.extra.cann.extension import sub_vec_id
+import numpy as np
+
+g_ash_size = 1024 * 1024 * 1024
+g_malloc_size = 8 * 1024 * 1024
+G_IP_PORT = "tcp://127.0.0.1:8666"
+
+# ANSI color codes
+GREEN = "\033[92m"
+RED = "\033[91m"
+RESET = "\033[0m"
+BOLD = "\033[1m"
+
+
+@triton.jit
+def kernel_gemm_allreduce(
+    # Pointers to matrices
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    peer_mem_ptr,
+    # Distributed parameters
+    rank,
+    rank_size,
+    buffer_num,
+    # Matrix dimensions
+    M,
+    N,
+    K,
+    # The stride variables represent how much to increase the ptr by when moving by 1
+    # element in a particular dimension. E.g. `stride_am` is how much to increase `a_ptr`
+    # by to get the element one row down (A has M rows).
+    stride_am,
+    stride_ak,  #
+    stride_bk,
+    stride_bn,  #
+    stride_cm,
+    stride_cn,
+    # Meta-parameters
+    pvalue: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    COMM_BLOCK_SIZE_M: tl.constexpr,
+    COMM_BLOCK_SIZE_N: tl.constexpr,
+):
+    """Kernel for computing the matmul C = A x B.
+    A has shape (M, K), B has shape (K, N) and C has shape (M, N)
+    """
+    subblock_idx = sub_vec_id()
+    ncore = tl.num_programs(axis=0)
+    pid = tl.program_id(axis=0)
+    loop_num_per_comm = ncore * pvalue
+    num_loops_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_loops_n = tl.cdiv(N, BLOCK_SIZE_N)
+    total_loops = num_loops_m * num_loops_n
+    num_loops_comm = tl.cdiv(total_loops, loop_num_per_comm)
+    buffer_row_size = BLOCK_SIZE_M * loop_num_per_comm
+    for global_id in range(0, num_loops_comm):
+        buffer_id = global_id % buffer_num
+        actual_loop_num_per_comm = loop_num_per_comm
+        output_block_id_offset = global_id * loop_num_per_comm
+        # process tail block
+        if global_id == num_loops_comm - 1:
+            actual_loop_num_per_comm = total_loops - global_id * loop_num_per_comm
+        num_k_blocks = tl.cdiv(K, BLOCK_SIZE_K)
+        for block_id in range(pid, actual_loop_num_per_comm, ncore):
+            block_id_m, block_id_n = gemm_swizzle2d_Nz(
+                output_block_id_offset + block_id,
+                M,
+                N,
+                BLOCK_SIZE_M,
+                BLOCK_SIZE_N,
+            )
+            accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N),
+                                   dtype=tl.float32)
+            matmul_offs_am = block_id_m * BLOCK_SIZE_M + tl.arange(
+                0, BLOCK_SIZE_M)
+            matmul_msk_am = matmul_offs_am[:, None] < M
+            offs_bn = block_id_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+            msk_n = offs_bn[None, :] < N
+            for block_id_k in range(0, num_k_blocks):
+                offs_k = tl.arange(0, BLOCK_SIZE_K) + block_id_k * BLOCK_SIZE_K
+                a_ptrs = a_ptr + (matmul_offs_am[:, None] * stride_am +
+                                  offs_k[None, :] * stride_ak)
+                b_ptrs = b_ptr + (offs_k[:, None] * stride_bk +
+                                  offs_bn[None, :] * stride_bn)
+                a = tl.load(a_ptrs,
+                            mask=(offs_k[None, :] < K) & matmul_msk_am,
+                            other=0.0)
+                b = tl.load(b_ptrs,
+                            mask=(offs_k[:, None] < K) & msk_n,
+                            other=0.0)
+                # We accumulate along the K dimension.
+                accumulator += tl.dot(a, b)
+            c = accumulator
+            # -----------------------------------------------------------
+            # Write the block of the output matrix C with masks.
+            offs_peer_mem_m = (buffer_id * buffer_row_size +
+                               block_id * BLOCK_SIZE_M +
+                               tl.arange(0, BLOCK_SIZE_M))
+            offs_peer_mem_n = tl.arange(0, BLOCK_SIZE_N)
+            peer_mem_ptrs = (peer_mem_ptr +
+                             BLOCK_SIZE_N * offs_peer_mem_m[:, None] +
+                             offs_peer_mem_n[None, :])
+            tl.store(peer_mem_ptrs, c)
+        libshmem_device.barrier_all()
+        comm_problem_size_m = actual_loop_num_per_comm * BLOCK_SIZE_M
+        comm_block_num = tl.cdiv(comm_problem_size_m,
+                                 COMM_BLOCK_SIZE_M) * tl.cdiv(
+                                     BLOCK_SIZE_N, COMM_BLOCK_SIZE_N)
+        if subblock_idx == 0:
+            for idx in range(pid, comm_block_num * rank_size, ncore):
+                block_id_m, block_id_n, target_rank, comm_row_shape, comm_col_shape = (
+                    dist_swizzle2d_Nz(
+                        idx,
+                        rank_size,
+                        comm_problem_size_m,
+                        BLOCK_SIZE_N,
+                        COMM_BLOCK_SIZE_M,
+                        COMM_BLOCK_SIZE_N,
+                    ))
+                remote_ptr = dl.symm_at(peer_mem_ptr, target_rank)
+                comm_offs_m = (tl.arange(0, COMM_BLOCK_SIZE_M) +
+                               block_id_m * COMM_BLOCK_SIZE_M +
+                               buffer_id * loop_num_per_comm * BLOCK_SIZE_M)
+                comm_offs_n = (tl.arange(0, COMM_BLOCK_SIZE_N) +
+                               block_id_n * COMM_BLOCK_SIZE_N)
+                remote_ptrs = remote_ptr + (
+                    comm_offs_m[:, None] * BLOCK_SIZE_N + comm_offs_n[None, :])
+                block_id = block_id_m * COMM_BLOCK_SIZE_M // BLOCK_SIZE_M
+                block_id_gemm_m, block_id_gemm_n = gemm_swizzle2d_Nz(
+                    output_block_id_offset + block_id, M, N, BLOCK_SIZE_M,
+                    BLOCK_SIZE_N)
+                m_offset_in_block = (block_id_m *
+                                     COMM_BLOCK_SIZE_M) % BLOCK_SIZE_M
+                n_offset_in_block = (block_id_n *
+                                     COMM_BLOCK_SIZE_N) % BLOCK_SIZE_N
+                offs_cm = (block_id_gemm_m * BLOCK_SIZE_M + m_offset_in_block +
+                           tl.arange(0, COMM_BLOCK_SIZE_M))
+                offs_cn = (block_id_gemm_n * BLOCK_SIZE_N + n_offset_in_block +
+                           tl.arange(0, COMM_BLOCK_SIZE_N))
+                c_offs = stride_cm * offs_cm[:, None] + stride_cn * offs_cn[
+                    None, :]
+                c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+                c_temp = tl.load(remote_ptrs)
+                tl.atomic_add(c_ptr + c_offs, c_temp, mask=c_mask)
+
+
+def gemm_allreduce(
+    A,
+    B,
+    C,
+    peer_mem,
+    rank,
+    rank_size,
+    buffer_num,
+    pvalue,
+    BLOCK_SIZE_M,
+    BLOCK_SIZE_N,
+    BLOCK_SIZE_K,
+    COMM_BLOCK_SIZE_M,
+    COMM_BLOCK_SIZE_N,
+):
+    """consume gemm"""
+    M, K = A.shape
+    _, N = B.shape
+    ncore = 20
+    assert ncore <= 20, "block num should less than or equal physical aicore num"
+    kernel_gemm_allreduce[ncore, 1, 1](
+        A,
+        B,
+        C,
+        peer_mem,
+        rank,
+        rank_size,
+        buffer_num,
+        M,
+        N,
+        K,
+        A.stride(0),
+        A.stride(1),
+        B.stride(0),
+        B.stride(1),
+        C.stride(0),
+        C.stride(1),
+        pvalue,
+        BLOCK_SIZE_M,
+        BLOCK_SIZE_N,
+        BLOCK_SIZE_K,
+        COMM_BLOCK_SIZE_M,
+        COMM_BLOCK_SIZE_N,
+    )
+
+
+def torch_gemm_allreduce(A_list, B_list, world_size):
+    """
+    Compute golden reference using PyTorch's matmul and all_reduce.
+
+    Args:
+        A_list: List of A matrices from all ranks (each on their respective device)
+        B_list: List of B matrices from all ranks (each on their respective device)
+        world_size: Number of ranks
+
+    Returns:
+        C_golden: The all-reduced result (C = sum(A_i @ B_i) for all ranks i)
+    """
+    # Get local rank
+    rank = dist.get_rank()
+
+    # Compute local C = A @ B
+    A_rank = A_list[rank]
+    B_rank = B_list[rank]
+    C_local = torch.matmul(A_rank.to(torch.float32), B_rank.to(torch.float32))
+
+    # Use torch.distributed.all_reduce to get the golden reference
+    C_golden = C_local.clone()
+    dist.all_reduce(C_golden, op=dist.ReduceOp.SUM)
+
+    return C_golden.to(torch.float16)
+
+
+def generate_matrices_for_rank(rank, M, N, K, dtype, seed_base=42):
+    """
+    Generate consistent A and B matrices for a given rank using a seed.
+
+    Args:
+        rank: Rank ID
+        M, N, K: Matrix dimensions
+        dtype: Data type
+        seed_base: Base seed for reproducibility
+
+    Returns:
+        A: Matrix of shape (M, K)
+        B: Matrix of shape (K, N)
+    """
+    # Use rank-specific seed for reproducibility
+    torch.manual_seed(seed_base + rank)
+    A = torch.randn([M, K], dtype=dtype)
+    B = torch.randn([K, N], dtype=dtype)
+    return A, B
+
+
+def run_test_distributed():
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 256
+    COMM_BLOCK_SIZE_M = 8
+    COMM_BLOCK_SIZE_N = 256
+    buffer_num = 2
+    pvalue = 4
+    ncore = 20
+    pe = dist.get_rank()
+    world_size = dist.get_world_size()
+    ret = ash.set_conf_store_tls(False, "")
+    if ret != 0:
+        raise ValueError("[ERROR] set_conf_store_tls failed")
+    attributes = ash.InitAttr()
+    attributes.my_rank = pe
+    attributes.n_ranks = world_size
+    attributes.local_mem_size = g_ash_size
+    attributes.ip_port = G_IP_PORT
+    attributes.option_attr.data_op_engine_type = ash.OpEngineType.MTE
+    ret = ash.aclshmem_init(attributes)
+    if ret != 0:
+        raise ValueError("[ERROR] aclshmem_init failed")
+
+    # Calculate peer_mem size based on world_size (supports any number of ranks)
+    peer_mem_size = (BLOCK_SIZE_M * pvalue * ncore * buffer_num *
+                     BLOCK_SIZE_N * world_size)
+    peer_mem = ash.aclshmem_create_tensor(
+        [peer_mem_size],
+        dtype=torch.float32,
+        device_id=pe,
+    )
+    C = torch.zeros([M, N], dtype=torch.float32).npu()
+
+    # Generate A and B matrices for all ranks using seeds
+    A_list = []
+    B_list = []
+    for i in range(world_size):
+        A_i, B_i = generate_matrices_for_rank(i, M, N, K, dtype)
+        A_list.append(A_i.npu())
+        B_list.append(B_i.npu())
+
+    # Extract local matrices
+    A_rank = A_list[pe]
+    B_rank = B_list[pe]
+
+    # Compute golden reference using torch_gemm_allreduce
+    C_golden = torch_gemm_allreduce(A_list, B_list, world_size)
+
+    gemm_allreduce(
+        A_rank,
+        B_rank,
+        C,
+        peer_mem,
+        pe,
+        world_size,
+        buffer_num,
+        pvalue,
+        BLOCK_SIZE_M,
+        BLOCK_SIZE_N,
+        BLOCK_SIZE_K,
+        COMM_BLOCK_SIZE_M,
+        COMM_BLOCK_SIZE_N,
+    )
+
+    passed = torch.tensor([1], dtype=torch.int32).npu()
+    error_msg = ""
+    try:
+        torch.testing.assert_close(C_golden,
+                                   C.to(torch.float16),
+                                   rtol=1e-3,
+                                   atol=1e-3)
+    except AssertionError as e:
+        passed[0] = 0
+        error_msg = str(e)
+        raise
+
+    # Gather all ranks' pass/fail status
+    all_passed = [
+        torch.zeros(1, dtype=torch.int32).npu() for _ in range(world_size)
+    ]
+    dist.all_gather(all_passed, passed)
+
+    # Print sequentially, one rank at a time
+    dist.barrier()
+    for rank_id in range(world_size):
+        if pe == rank_id:
+            if all_passed[rank_id].item() == 1:
+                print(
+                    f"{GREEN}[PASS]{RESET} Rank {pe}: C_golden and C match within tolerances (rtol=1e-3, atol=1e-3).",
+                    flush=True,
+                )
+            else:
+                print(
+                    f"{RED}[FAIL]{RESET} Rank {pe}: C_golden and C do NOT match. Details:\n{error_msg}",
+                    flush=True,
+                )
+        dist.barrier()
+    # Raise if any rank failed
+    if any(r.item() == 0 for r in all_passed):
+        if passed.item() == 0:
+            raise AssertionError(error_msg)
+
+    ash.aclshmem_free_tensor(peer_mem)
+    _ = ash.aclshmem_finialize()
+
+
+if __name__ == "__main__":
+    local_pe = int(os.environ["LOCAL_RANK"])
+    torch.npu.set_device(local_pe)
+    dist.init_process_group(backend="hccl", rank=local_pe)
+    dtype, M, N, K = [torch.float16, 4096, 4096, 4096]
+    world_size = dist.get_world_size()
+
+    print(f"[INFO] Rank {local_pe} of {world_size} initialized")
+    dist.barrier()
+    run_test_distributed()
+    if local_pe == 0:
+        print(f"[INFO] Test passed successfully for {world_size} ranks!")


### PR DESCRIPTION
## Summary
1. Implement ascend backend include python primitives and conversion passes
2. Adapt setup.py and cmake project for triton-ascend
3. Add tutorials cases for fusion kernels, allgather+gemm, gemm+reduce_scatter, gemm+allreduce
4. Add unittest for ascend backend in python/triton_dist/test/ascend
5. Add triton-ascend and shmem as submodule
6. Add common gemm-swizzle and comm-swizzle algorithm