### PR TITLE
Update AMD build doc AND Make rocshmem device-bitcode arch configurable

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -141,6 +141,14 @@ See examples in the `tutorials` directory at the project root.
 ## To use Triton-distributed with the AMD backend:
 Starting from the rocm/pytorch:rocm7.1_ubuntu24.04_py3.12_pytorch_release_2.7.1 Docker container
 #### AMD Build Steps
+0. Detect your GPU architecture and export it. 
+```sh
+# e.g. gfx950 for MI350, gfx942 for MI300
+python3 -c "import torch; print(torch.cuda.get_device_properties(0).gcnArchName.split(':')[0])"
+export BITCODE_LIB_ARCH=gfx950   # ← replace with the value printed above
+```
+If this environment variable is not set, the default value is "gfx942"
+
 1. Clone the repo
 ```sh
 git clone https://github.com/ByteDance-Seed/Triton-distributed.git
@@ -162,12 +170,15 @@ export TRITON_BUILD_PROTON=0
 rm -f /usr/local/bin/cmake
 apt-get update -y
 apt install -y libopenmpi-dev git cython3 ibverbs-utils openmpi-bin libopenmpi-dev libpci-dev libdw1 locales cmake miopen-hip autoconf libtool flex ninja-build clang lld
-python3 -m pip install -i https://test.pypi.org/simple hip-python>=7.1 # (or whatever Rocm version you have)
+python3 -m pip install -i https://test.pypi.org/simple 'hip-python>=7.1' # (or whatever Rocm version you have)
 pip3 install pybind11
 bash ./shmem/rocshmem_bind/build.sh
 ```
 4. Build Triton-distributed
 ```sh
+# Uninstall the original Triton
+pip3 uninstall -y triton
+
 pip3 install -e python --verbose --no-build-isolation --use-pep517
 ```
 ### Test AMD Installation

--- a/shmem/rocshmem_bind/scripts/build_rocshmem_device_bc.sh
+++ b/shmem/rocshmem_bind/scripts/build_rocshmem_device_bc.sh
@@ -10,7 +10,7 @@ export OMPI_DIR="${OMPI_INSTALL_DIR:-/opt/ompi_build}/install/ompi"
 
 pushd ${ROCSHMEM_INSTALL_DIR}/lib
 
-export BITCODE_LIB_ARCH=gfx942
+export BITCODE_LIB_ARCH=${BITCODE_LIB_ARCH:-gfx942}
 CLANG="${ROCM_CXX:-${ROCM_PATH}/lib/llvm/bin/clang++}"
 CLANG_FLAGS=(
     -x hip


### PR DESCRIPTION
## Summary
I follow the AMD build flow on `8x AMD Instinct MI350X (gfx950)` inside the
`rocm/pytorch:rocm7.1_ubuntu24.04_py3.12_pytorch_release_2.7.1` container,
using the steps in `docs/build.md`. I had met some errors and fix them

- `shmem/rocshmem_bind/scripts/build_rocshmem_device_bc.sh` hard-codes
  `BITCODE_LIB_ARCH=gfx942` (MI300X), so the resulting rocshmem device
  bitcode does not fit  MI350 (gfx950) or any other non-MI300 GPU. 
  So i make it configurable and keep gfx942 as default . so that it wont affet users using MI300

- `docs/build.md` (AMD section): fill in a couple of missing/typo steps —
  add step 0 to detect and `export BITCODE_LIB_ARCH=<gfxXXX>`, quote
  `'hip-python>=7.1'` (otherwise the shell parses `>=7.1` as a
  redirection), and `pip uninstall -y triton` before `pip install -e python`
  to uninstall the origin triton

## TEST
- [x] `bash ./scripts/launch_amd.sh ./python/triton_dist/test/amd/test_ag_gemm_intra_node.py 8192 8192 29568` → `✅ all close!`
- [x] `TRITON_DIST_SHMEM_BACKEND=mori_shmem bash ./scripts/launch_amd.sh ./python/triton_dist/test/amd/test_ep_a2a.py --check` → `RANK[*]: all checks passed.`
