### PR TITLE
add fused EP all-to-all mega kernels(forward) for AMD GPUs

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -995,6 +995,7 @@ def get_packages():
             "triton_dist/mega_triton_kernel",
             "triton_dist/function",
             "triton_dist/function/nvidia",
+            "triton_dist/function/amd",
             "triton_dist/layers",
             "triton_dist/layers/nvidia",
             "triton_dist/layers/amd",

--- a/python/triton_dist/function/amd/__init__.py
+++ b/python/triton_dist/function/amd/__init__.py
@@ -22,32 +22,15 @@
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 ################################################################################
-from .ep_ll_a2a_layer import EPLowLatencyAllToAllLayer
-
-__all__ = [
-    "EPLowLatencyAllToAllLayer",
-]
+__all__ = []
 
 try:
-    from .ep_a2a_layer import EPAll2AllLayer
-    __all__.append("EPAll2AllLayer")
-except ImportError:
-    pass
-
-try:
-    from .tp_attn import TP_Attn
-    __all__.append("TP_Attn")
-except ImportError:
-    pass
-
-try:
-    from .tp_mlp import TP_MLP
-    __all__.append("TP_MLP")
-except ImportError:
-    pass
-
-try:
-    from .ep_a2a_fused_layer import EpAll2AllFusedOp, EPAll2AllFusedLayer
-    __all__ += ["EpAll2AllFusedOp", "EPAll2AllFusedLayer"]
-except ImportError:
-    pass
+    from .ep_moe_fused import (
+        TritonDistFusedEpMoeFunction,
+        fused_ep_moe,
+        fused_ep_moe_autograd,
+    )
+    __all__ += ["TritonDistFusedEpMoeFunction", "fused_ep_moe", "fused_ep_moe_autograd"]
+except ImportError as e:
+    import warnings
+    warnings.warn(f"function.amd.ep_moe_fused unavailable (mori_shmem not installed?): {e}")

--- a/python/triton_dist/function/amd/ep_moe_fused.py
+++ b/python/triton_dist/function/amd/ep_moe_fused.py
@@ -33,6 +33,9 @@ Runs the full fused MoE forward on top of an ``EpAll2AllFusedOp``:
     ``w1_local = [experts_per_rank, hidden, inter]``,
     ``w2_local = [experts_per_rank, inter, hidden]``;
   * the caller passes a pre-built ``EpAll2AllFusedOp`` (which owns the symmetric buffers).
+
+Dispatch/combine metadata is built on-device by default; pass
+``EpAll2AllFusedOp(..., use_device_metadata=False)`` to fall back to the host torch path.
 """
 
 from typing import Callable, Optional

--- a/python/triton_dist/function/amd/ep_moe_fused.py
+++ b/python/triton_dist/function/amd/ep_moe_fused.py
@@ -1,0 +1,93 @@
+################################################################################
+#
+# Copyright (c) 2025 ByteDance Ltd. and/or its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+################################################################################
+"""
+AMD (HIP/ROCm) model-facing fused EP MoE.
+
+Runs the full fused MoE forward on top of an ``EpAll2AllFusedOp``:
+
+    dispatch + grouped GEMM-1 (up)  ->  activation  ->  grouped GEMM-2 (down) + combine
+
+  * expert weights are this rank's local slices (EP sharding):
+    ``w1_local = [experts_per_rank, hidden, inter]``,
+    ``w2_local = [experts_per_rank, inter, hidden]``;
+  * the caller passes a pre-built ``EpAll2AllFusedOp`` (which owns the symmetric buffers).
+"""
+
+from typing import Callable, Optional
+
+import torch
+
+from triton_dist.layers.amd.ep_a2a_fused_layer import EpAll2AllFusedOp
+
+
+def fused_ep_moe(
+    layer: EpAll2AllFusedOp,
+    hidden_states: torch.Tensor,  # [num_tokens, hidden]
+    selected_experts: torch.Tensor,  # [num_tokens, topk] int32, global expert ids
+    w1_local: torch.Tensor,  # [experts_per_rank, hidden, inter]
+    w2_local: torch.Tensor,  # [experts_per_rank, inter, hidden]
+    routing_weights: Optional[torch.Tensor] = None,  # [num_tokens, topk]
+    activation: Callable[[torch.Tensor], torch.Tensor] = torch.relu,
+) -> torch.Tensor:
+    """Functional (inference) entry: full fused MoE forward; returns ``[num_tokens, hidden]``."""
+    return layer.forward(hidden_states, selected_experts, w1_local, w2_local, topk_weights=routing_weights,
+                         activation=activation)
+
+
+class TritonDistFusedEpMoeFunction(torch.autograd.Function):
+    """``torch.autograd.Function`` wrapper around the fused MoE forward."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        hidden_states: torch.Tensor,
+        selected_experts: torch.Tensor,
+        routing_weights: Optional[torch.Tensor],
+        w1_local: torch.Tensor,
+        w2_local: torch.Tensor,
+        layer: EpAll2AllFusedOp,
+        activation: Callable[[torch.Tensor], torch.Tensor] = torch.relu,
+    ) -> torch.Tensor:
+        ctx.set_materialize_grads(False)
+        return layer.forward(hidden_states, selected_experts, w1_local, w2_local, topk_weights=routing_weights,
+                             activation=activation)
+
+    @staticmethod
+    def backward(ctx, *grad_outputs):
+        raise NotImplementedError("backward is not implemented")
+
+
+def fused_ep_moe_autograd(
+    layer: EpAll2AllFusedOp,
+    hidden_states: torch.Tensor,
+    selected_experts: torch.Tensor,
+    w1_local: torch.Tensor,
+    w2_local: torch.Tensor,
+    routing_weights: Optional[torch.Tensor] = None,
+    activation: Callable[[torch.Tensor], torch.Tensor] = torch.relu,
+) -> torch.Tensor:
+    """Same as ``fused_ep_moe`` but routed through the autograd ``Function``."""
+    return TritonDistFusedEpMoeFunction.apply(hidden_states, selected_experts, routing_weights, w1_local, w2_local,
+                                              layer, activation)

--- a/python/triton_dist/kernels/amd/__init__.py
+++ b/python/triton_dist/kernels/amd/__init__.py
@@ -38,11 +38,28 @@ except ImportError as e:
     import warnings
     warnings.warn(f"allgather_gemm/gemm_reduce_scatter unavailable (pyrocshmem not installed): {e}")
 
+try:
+    from .ep_all2all_fused import (
+        create_ep_a2a_fused_context,
+        fused_dispatch_token_moe_grouped_gemm,
+        fused_group_gemm_combine_token,
+        mega_kernel_dispatch_token_moe_grouped_gemm,
+        mega_kernel_moe_grouped_gemm_combine_token,
+    )
+except ImportError as e:
+    import warnings
+    warnings.warn(f"ep_all2all_fused unavailable (mori_shmem not installed): {e}")
+
 __all__ = [
     "ag_gemm_intra_node",
     "create_ag_gemm_intra_node_context",
     "gemm_rs_intra_node",
     "create_gemm_rs_intra_node_context",
+    "create_ep_a2a_fused_context",
+    "fused_dispatch_token_moe_grouped_gemm",
+    "fused_group_gemm_combine_token",
+    "mega_kernel_dispatch_token_moe_grouped_gemm",
+    "mega_kernel_moe_grouped_gemm_combine_token",
     "kernel_dispatch_token_intra_node",
     "kernel_skipped_token_local_dispatch_intra_node",
     "kernel_skipped_token_inplace_local_combine_intra_node",

--- a/python/triton_dist/kernels/amd/__init__.py
+++ b/python/triton_dist/kernels/amd/__init__.py
@@ -38,6 +38,21 @@ except ImportError as e:
     import warnings
     warnings.warn(f"allgather_gemm/gemm_reduce_scatter unavailable (pyrocshmem not installed): {e}")
 
+__all__ = [
+    "ag_gemm_intra_node",
+    "create_ag_gemm_intra_node_context",
+    "gemm_rs_intra_node",
+    "create_gemm_rs_intra_node_context",
+    "kernel_dispatch_token_intra_node",
+    "kernel_skipped_token_local_dispatch_intra_node",
+    "kernel_skipped_token_inplace_local_combine_intra_node",
+    "kernel_combine_token_intra_node",
+    "get_ag_splits_and_recv_offset_for_dispatch_intra_node",
+    "create_all_to_all_context",
+    "fast_all_to_all",
+    "all_to_all_post_process",
+]
+
 try:
     from .ep_all2all_fused import (
         create_ep_a2a_fused_context,
@@ -48,28 +63,15 @@ try:
         kernel_build_fused_dispatch_metadata,
         kernel_build_gemm_tiling,
     )
+    __all__ += [
+        "create_ep_a2a_fused_context",
+        "fused_dispatch_token_moe_grouped_gemm",
+        "fused_group_gemm_combine_token",
+        "mega_kernel_dispatch_token_moe_grouped_gemm",
+        "mega_kernel_moe_grouped_gemm_combine_token",
+        "kernel_build_fused_dispatch_metadata",
+        "kernel_build_gemm_tiling",
+    ]
 except ImportError as e:
     import warnings
     warnings.warn(f"ep_all2all_fused unavailable (mori_shmem not installed): {e}")
-
-__all__ = [
-    "ag_gemm_intra_node",
-    "create_ag_gemm_intra_node_context",
-    "gemm_rs_intra_node",
-    "create_gemm_rs_intra_node_context",
-    "create_ep_a2a_fused_context",
-    "fused_dispatch_token_moe_grouped_gemm",
-    "fused_group_gemm_combine_token",
-    "mega_kernel_dispatch_token_moe_grouped_gemm",
-    "mega_kernel_moe_grouped_gemm_combine_token",
-    "kernel_build_fused_dispatch_metadata",
-    "kernel_build_gemm_tiling",
-    "kernel_dispatch_token_intra_node",
-    "kernel_skipped_token_local_dispatch_intra_node",
-    "kernel_skipped_token_inplace_local_combine_intra_node",
-    "kernel_combine_token_intra_node",
-    "get_ag_splits_and_recv_offset_for_dispatch_intra_node",
-    "create_all_to_all_context",
-    "fast_all_to_all",
-    "all_to_all_post_process",
-]

--- a/python/triton_dist/kernels/amd/__init__.py
+++ b/python/triton_dist/kernels/amd/__init__.py
@@ -45,6 +45,8 @@ try:
         fused_group_gemm_combine_token,
         mega_kernel_dispatch_token_moe_grouped_gemm,
         mega_kernel_moe_grouped_gemm_combine_token,
+        kernel_build_fused_dispatch_metadata,
+        kernel_build_gemm_tiling,
     )
 except ImportError as e:
     import warnings
@@ -60,6 +62,8 @@ __all__ = [
     "fused_group_gemm_combine_token",
     "mega_kernel_dispatch_token_moe_grouped_gemm",
     "mega_kernel_moe_grouped_gemm_combine_token",
+    "kernel_build_fused_dispatch_metadata",
+    "kernel_build_gemm_tiling",
     "kernel_dispatch_token_intra_node",
     "kernel_skipped_token_local_dispatch_intra_node",
     "kernel_skipped_token_inplace_local_combine_intra_node",

--- a/python/triton_dist/kernels/amd/ep_a2a.py
+++ b/python/triton_dist/kernels/amd/ep_a2a.py
@@ -46,7 +46,9 @@ def kernel_bincount(n, input, output, length, num_sm, num_warps: tl.constexpr):
     threads_per_block = num_warps * threads_per_warp()
     for i in range(pid * threads_per_block + thread_idx, n, num_pid * threads_per_block):
         val = ld(input + i)
-        if val < length:
+        # lower bound guards against negative/sentinel ids writing out of bounds before any
+        # host-side range check runs (e.g. the device-metadata path bincounts before validation)
+        if val >= 0 and val < length:
             atomic_add(output + val, 1, scope="agent", semantic="relaxed")
 
 

--- a/python/triton_dist/kernels/amd/ep_all2all_fused.py
+++ b/python/triton_dist/kernels/amd/ep_all2all_fused.py
@@ -23,33 +23,23 @@
 #
 ################################################################################
 """
-AMD (HIP/ROCm) fused EP All-to-All + grouped GEMM "mega kernel" (intra-node).
+AMD (HIP/ROCm) fused EP All-to-All + grouped GEMM "mega kernel".
 
-This is the AMD counterpart of ``kernels/nvidia/ep_all2all_fused.py``. It fuses
-MoE token *dispatch* (expert-parallel all-to-all) with the expert *grouped GEMM*
-into a single persistent kernel so that, as soon as an expert's tokens have
+Fuses MoE token *dispatch* (expert-parallel all-to-all) with the expert *grouped
+GEMM* into a single persistent kernel so that, as soon as an expert's tokens have
 arrived from every source rank, its GEMM tiles can start -- overlapping
-communication with compute at tile granularity.
+communication with compute at tile granularity. (Reference design:
+``kernels/nvidia/ep_all2all_fused.py``.)
 
-Mapping NVIDIA -> AMD:
-  * NVSHMEM device put/signal      -> mori via ``libshmem_device`` proxy
-                                      (``putmem_warp`` / ``signal_op`` / ``signal_wait_until``)
-  * ``NVSHMEM_SIGNAL_DTYPE`` int64 -> ``MORI_SHMEM_SIGNAL_DTYPE`` uint64
-  * ``nvshmem_create_tensor``      -> ``mori_shmem_create_tensor``
-  * warp size 32 / ``sync_warp``   -> wavefront 64 / ``threads_per_warp()``
-  * ``ld_acquire(.., "gpu")``      -> ``ld(.., scope="agent", semantic="acquire")``
-  * cooperative-grid env-reg trick -> not needed (CTAs coordinate purely through
-                                      the per-expert symmetric barrier buffer)
-  * TMA / descriptor GEMM          -> plain pointer-arithmetic ``tl.dot``
-
-Scope: the forward path is implemented as two mega kernels --
-``dispatch + grouped GEMM(1)`` and ``grouped GEMM(2) + combine`` (serial / gather
-mode). Not implemented here (same pattern, deferred): scatter-combine mode,
-transposed/backward grouped GEMM, FP8 online quant, profiler instrumentation,
-the two-stage (local-checkpoint) dispatch and the lazy symmetric allocator. Drop
-tokens are not supported (asserted on entry). Cross-rank split exchange and
-grouped-GEMM tiling metadata are computed on the host in plain torch (run once
-per call); the data plane stays inside the fused kernels.
+The forward path is two mega kernels: ``dispatch + grouped GEMM(1)`` and
+``grouped GEMM(2) + combine`` (serial / gather combine). Cross-rank data movement
+and synchronization use mori_shmem device primitives via ``libshmem_device``
+(``putmem_warp`` / ``signal_op`` / ``signal_wait_until`` / ``barrier_all``);
+symmetric buffers come from ``mori_shmem_create_tensor`` and a per-expert
+``MORI_SHMEM_SIGNAL_DTYPE`` (uint64) barrier; the wavefront width is 64 and
+grouped-GEMM tiles are plain pointer-arithmetic ``tl.dot``. The cross-rank split
+exchange and grouped-GEMM tiling metadata are computed on the host in plain torch
+(run once per call); the data plane stays inside the fused kernels.
 """
 
 import math
@@ -100,8 +90,7 @@ def dot_k_const(
 ):
     """A single (BLOCK_M, BLOCK_N) GEMM tile with a K reduction loop.
 
-    Plain ``tl.dot`` accumulation in fp32 (no TMA, no warp-specialization --
-    both NVIDIA-only).
+    Plain ``tl.dot`` accumulation in fp32.
     """
     accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
     for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
@@ -427,7 +416,7 @@ class EpA2AFusedContext:
     num_tot_experts: int
     experts_per_rank: int
     dtype: torch.dtype
-    weight_dtype: torch.dtype
+    weight_dtype: torch.dtype  # Not in use; reserved for future path
     capacity: float
     cap_tokens: int
 
@@ -461,7 +450,7 @@ def create_ep_a2a_fused_context(
     rank: int,
     world_size: int,
     dtype: torch.dtype = torch.bfloat16,
-    weight_dtype: torch.dtype = torch.float32,
+    weight_dtype: torch.dtype = torch.float32,  # Not in use; reserved for future path
     capacity: float = 4.0,
 ) -> EpA2AFusedContext:
     assert num_tot_experts % world_size == 0, "num_tot_experts must be divisible by world_size"
@@ -523,6 +512,7 @@ def _build_gemm_tiling(split_size: torch.Tensor, block_m: int, device):
         return torch.tensor(lst, dtype=torch.int32, device=device)
 
     return dict(
+        block_m=block_m,
         expert_ids=_i32(expert_ids),
         split_size_cum=_i32(split_size_cum),
         tile_num=_i32(tile_num),
@@ -576,6 +566,8 @@ def fused_dispatch_token_moe_grouped_gemm(
     input: torch.Tensor,  # [num_tokens, hidden] this rank's tokens
     topk_indices: torch.Tensor,  # [num_tokens, topk] int32 (global expert ids)
     gemm_weight: torch.Tensor,  # [experts_per_rank, hidden, N]
+    *,  # keyword-only below: avoids any silent positional misbind of the new `meta` arg
+    meta: Optional[dict] = None,  # precomputed layout metadata (e.g. from a layer.preprocess); built if None
     num_sms: int = 64,
     num_dispatch_tasks: int = 20,
     BLOCK_SIZE_M: int = 128,
@@ -592,21 +584,31 @@ def fused_dispatch_token_moe_grouped_gemm(
     counts) needed by a subsequent combine.
     """
     assert input.is_contiguous() and input.dtype == ctx.dtype
-    assert topk_indices.dtype == torch.int32 and topk_indices.shape[1] == ctx.topk
+    assert topk_indices.dtype == torch.int32 and topk_indices.shape[1] == ctx.topk and topk_indices.is_contiguous()
+    assert gemm_weight.dtype == ctx.dtype, "expert weights must match the activation dtype (ctx.dtype)"
     num_tokens, hidden = input.shape
     assert hidden == ctx.hidden and num_tokens <= ctx.max_tokens
     G, K, N = gemm_weight.shape
     assert G == ctx.experts_per_rank and K == ctx.hidden
-    # Drop tokens are unsupported: every (token, slot) must map to a real expert.
+    # Every (token, slot) must map to a real expert in [0, num_tot_experts).
     assert bool(((topk_indices >= 0) & (topk_indices < ctx.num_tot_experts)).all()), \
-        "topk_indices out of [0, num_tot_experts); drop tokens are not supported"
+        "topk_indices out of range [0, num_tot_experts)"
 
-    meta = _build_dispatch_metadata(ctx, topk_indices, BLOCK_SIZE_M)
+    if meta is None:
+        meta = _build_dispatch_metadata(ctx, topk_indices, BLOCK_SIZE_M)
+    else:
+        assert meta.get("block_m") == BLOCK_SIZE_M, \
+            "precomputed meta was built with a different BLOCK_SIZE_M than this launch"
     M = meta["M_local"]
     device = input.device
-    if M > ctx.cap_tokens:
+    # Global capacity check: every rank evaluates the same all-gathered per-rank recv counts,
+    # so all ranks raise together. A per-rank ``M > cap_tokens`` check would let under-capacity
+    # ranks fall through into the barrier/kernel while overflowing ranks bail out -> hang.
+    max_recv = int(meta["num_recv_tokens_per_rank"].max().item())
+    if max_recv > ctx.cap_tokens:
         raise RuntimeError(
-            f"received M={M} routed tokens > cap_tokens={ctx.cap_tokens}; increase `capacity` or `max_tokens`")
+            f"a rank would receive up to {max_recv} routed tokens > cap_tokens={ctx.cap_tokens}; "
+            "increase `capacity` or `max_tokens`")
     num_sms = min(num_sms, torch.cuda.get_device_properties(device).multi_processor_count)
 
     # stage this rank's tokens into the symmetric send buffer (putmem source)
@@ -778,7 +780,7 @@ def mega_kernel_moe_grouped_gemm_combine_token(
     grid_sync_counter,  # local int32 [1]
     NUM_WARPS: tl.constexpr,
 ):
-    """Serial-mode combine mega kernel (mirrors NVIDIA non-scatter path):
+    """Serial-mode combine mega kernel:
 
       phase 1: every CTA strides over the grouped-GEMM(2) tiles, writing the
                down-proj output into the symmetric ``c_ptr``.
@@ -868,11 +870,15 @@ def fused_group_gemm_combine_token(
     G, K2, N2 = gemm_weight.shape
     assert G == ctx.experts_per_rank
     assert N2 == ctx.hidden, "combine maps expert outputs back to `hidden`; expected N2 == ctx.hidden"
-    assert topk_indices.dtype == torch.int32 and topk_indices.shape[1] == ctx.topk
+    assert gemm_weight.dtype == ctx.dtype, "expert weights must match the activation dtype (ctx.dtype)"
+    assert topk_indices.dtype == torch.int32 and topk_indices.shape[1] == ctx.topk and topk_indices.is_contiguous()
     device = gemm_input.device
-    if M > ctx.cap_tokens:
+    # Global capacity check (see fused_dispatch_token_moe_grouped_gemm): raise on every rank together.
+    max_recv = int(meta["num_recv_tokens_per_rank"].max().item())
+    if max_recv > ctx.cap_tokens:
         raise RuntimeError(
-            f"received M={M} routed tokens > cap_tokens={ctx.cap_tokens}; increase `capacity` or `max_tokens`")
+            f"a rank would receive up to {max_recv} routed tokens > cap_tokens={ctx.cap_tokens}; "
+            "increase `capacity` or `max_tokens`")
     num_sms = min(num_sms, torch.cuda.get_device_properties(device).multi_processor_count)
 
     has_gate = topk_weights is not None

--- a/python/triton_dist/kernels/amd/ep_all2all_fused.py
+++ b/python/triton_dist/kernels/amd/ep_all2all_fused.py
@@ -1,0 +1,942 @@
+################################################################################
+#
+# Copyright (c) 2025 ByteDance Ltd. and/or its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+################################################################################
+"""
+AMD (HIP/ROCm) fused EP All-to-All + grouped GEMM "mega kernel" (intra-node).
+
+This is the AMD counterpart of ``kernels/nvidia/ep_all2all_fused.py``. It fuses
+MoE token *dispatch* (expert-parallel all-to-all) with the expert *grouped GEMM*
+into a single persistent kernel so that, as soon as an expert's tokens have
+arrived from every source rank, its GEMM tiles can start -- overlapping
+communication with compute at tile granularity.
+
+Mapping NVIDIA -> AMD:
+  * NVSHMEM device put/signal      -> mori via ``libshmem_device`` proxy
+                                      (``putmem_warp`` / ``signal_op`` / ``signal_wait_until``)
+  * ``NVSHMEM_SIGNAL_DTYPE`` int64 -> ``MORI_SHMEM_SIGNAL_DTYPE`` uint64
+  * ``nvshmem_create_tensor``      -> ``mori_shmem_create_tensor``
+  * warp size 32 / ``sync_warp``   -> wavefront 64 / ``threads_per_warp()``
+  * ``ld_acquire(.., "gpu")``      -> ``ld(.., scope="agent", semantic="acquire")``
+  * cooperative-grid env-reg trick -> not needed (CTAs coordinate purely through
+                                      the per-expert symmetric barrier buffer)
+  * TMA / descriptor GEMM          -> plain pointer-arithmetic ``tl.dot``
+
+Scope: the forward path is implemented as two mega kernels --
+``dispatch + grouped GEMM(1)`` and ``grouped GEMM(2) + combine`` (serial / gather
+mode). Not implemented here (same pattern, deferred): scatter-combine mode,
+transposed/backward grouped GEMM, FP8 online quant, profiler instrumentation,
+the two-stage (local-checkpoint) dispatch and the lazy symmetric allocator. Drop
+tokens are not supported (asserted on entry). Cross-rank split exchange and
+grouped-GEMM tiling metadata are computed on the host in plain torch (run once
+per call); the data plane stays inside the fused kernels.
+"""
+
+import math
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+import triton
+import triton.language as tl
+
+import triton_dist
+import triton_dist.language as dl
+from triton_dist.language.extra import libshmem_device
+from triton_dist.language.extra.hip.language_extra import (
+    tid,
+    __syncthreads,
+    ld,
+    st,
+    atomic_add,
+    atomic_add_per_warp,
+)
+from triton_dist.kernels.amd.common_ops import barrier_on_this_grid
+from triton_dist.utils import (
+    MORI_SHMEM_SIGNAL_DTYPE,
+    mori_shmem_create_tensor,
+    mori_shmem_free_tensor_sync,
+    mori_shmem_barrier_all_on_stream,
+)
+
+
+# ---------------------------------------------------------------------------
+#  Device helpers
+# ---------------------------------------------------------------------------
+@triton_dist.jit
+def dot_k_const(
+    a_ptrs,
+    b_ptrs,
+    c_ptrs,
+    M,
+    N,
+    K: tl.constexpr,
+    stride_ak: tl.constexpr,
+    stride_bk: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    need_mask: tl.constexpr,
+):
+    """A single (BLOCK_M, BLOCK_N) GEMM tile with a K reduction loop.
+
+    Plain ``tl.dot`` accumulation in fp32 (no TMA, no warp-specialization --
+    both NVIDIA-only).
+    """
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        if need_mask:
+            a = tl.load(
+                a_ptrs, mask=((tl.arange(0, BLOCK_SIZE_M) < M)[:, None] &
+                              (k * BLOCK_SIZE_K + tl.arange(0, BLOCK_SIZE_K) < K)[None, :]))
+        else:
+            a = tl.load(a_ptrs, mask=(k * BLOCK_SIZE_K + tl.arange(0, BLOCK_SIZE_K) < K)[None, :])
+        b = tl.load(b_ptrs, mask=(k * BLOCK_SIZE_K + tl.arange(0, BLOCK_SIZE_K) < K)[:, None])
+
+        accumulator = tl.dot(a, b, accumulator)
+        a_ptrs += BLOCK_SIZE_K * stride_ak
+        b_ptrs += BLOCK_SIZE_K * stride_bk
+
+    accumulator = accumulator.to(c_ptrs.dtype.element_ty)
+    if need_mask:
+        c_mask = (tl.arange(0, BLOCK_SIZE_M) < M)[:, None] & (tl.arange(0, BLOCK_SIZE_N) < N)[None, :]
+        tl.store(c_ptrs, accumulator, mask=c_mask)
+    else:
+        c_mask = (tl.arange(0, BLOCK_SIZE_N) < N)[None, :]
+        tl.store(c_ptrs, accumulator, mask=c_mask)
+
+
+# ---------------------------------------------------------------------------
+#  Dispatch tile (producer): scatter local tokens to remote expert ranks
+# ---------------------------------------------------------------------------
+@triton_dist.jit(do_not_specialize=["pid", "num_pid"])
+def tile_kernel_dispatch_token_intra_node(
+    pid,
+    num_pid,
+    counter_ptr,  # local int32 [num_experts]: per-global-expert sent counter
+    barriers_ptr,  # symm uint64 [experts_per_rank * world_size]: per (local_expert, src_rank)
+    recv_buf_offset_per_expert,  # int32 [world_size, experts_per_rank, world_size] exclusive offsets
+    local_splits_buf,  # int32 [num_experts]: this rank's token count per global expert
+    send_buf,  # symm: this rank's tokens [max_tokens, hidden] (putmem source)
+    output_buf,  # symm: per-rank recv region [cap_tokens, hidden] (putmem dest)
+    topk_indices_tensor,  # int32 [num_tokens, topk]
+    token_dst_scatter_idx,  # int32 [num_tokens, topk]
+    num_input_tokens_per_rank,  # int32 [world_size]
+    topk: tl.constexpr,
+    hidden_size: tl.constexpr,
+    experts_per_rank: tl.constexpr,
+    WITH_SCATTER_INDICES: tl.constexpr,
+    num_warps: tl.constexpr,
+):
+    WARP_SIZE: tl.constexpr = 64
+    ELEMENT_SIZE: tl.constexpr = tl.constexpr(send_buf.dtype.element_ty.primitive_bitwidth) // 8
+    bytes_per_token: tl.constexpr = hidden_size * ELEMENT_SIZE
+
+    rank = dl.rank()
+    world_size = dl.num_ranks()
+    thread_idx = tid(0)
+    lane_idx = thread_idx % WARP_SIZE
+    warp_id = thread_idx // WARP_SIZE
+    total_warps = num_warps * num_pid
+    global_warp_id = pid * num_warps + warp_id
+
+    token_num = tl.load(num_input_tokens_per_rank + rank)
+
+    # Each warp cooperatively transfers one (token, topk-slot) at a time.
+    for flat_off in range(global_warp_id, token_num * topk, total_warps):
+        token_offset = flat_off // topk
+        j = flat_off % topk
+        expert_idx = ld(topk_indices_tensor + token_offset * topk + j)
+        expert_rank = expert_idx // experts_per_rank
+        expert_idx_intra_rank = expert_idx % experts_per_rank
+
+        if expert_rank < world_size:
+            if not WITH_SCATTER_INDICES:
+                # Atomically reserve a destination slot in the target rank's recv
+                # region. `recv_buf_offset_per_expert` is seeded with exclusive
+                # prefix offsets on the host and bumped here per token.
+                store_idx = atomic_add_per_warp(
+                    recv_buf_offset_per_expert + expert_rank * experts_per_rank * world_size +
+                    expert_idx_intra_rank * world_size + rank, 1, scope="agent", semantic="relaxed")
+                if lane_idx == 0:
+                    st(token_dst_scatter_idx + token_offset * topk + j, store_idx)
+            else:
+                store_idx = ld(token_dst_scatter_idx + token_offset * topk + j)
+
+            src_ptr = send_buf + token_offset * hidden_size
+            dst_ptr = output_buf + store_idx.to(tl.int64) * hidden_size
+            libshmem_device.putmem_warp(dst_ptr, src_ptr, bytes_per_token, expert_rank)
+
+            # When this rank has sent its last token for `expert_idx`, release the
+            # destination's per-(local_expert, src_rank) barrier so the consuming
+            # GEMM tile can start.
+            if lane_idx == 0:
+                tokens_this_expert = ld(local_splits_buf + expert_idx)
+                sent = atomic_add(counter_ptr + expert_idx, 1, scope="agent", semantic="relaxed")
+                if sent == tokens_this_expert - 1:
+                    libshmem_device.fence()
+                    libshmem_device.signal_op(
+                        barriers_ptr + expert_idx_intra_rank * world_size + rank,
+                        1,
+                        libshmem_device.MORI_SIGNAL_SET,
+                        expert_rank,
+                    )
+
+    # Pre-signal barriers for experts this rank sends zero tokens to, otherwise a
+    # consumer expecting tokens from this (empty) source rank would spin forever.
+    # NOTE: indexes by expert_local (not expert_rank) so producer/consumer barrier
+    # addressing stays consistent.
+    if pid == 0:
+        for i in range(thread_idx, experts_per_rank * world_size, num_warps * WARP_SIZE):
+            if ld(local_splits_buf + i) == 0:
+                empty_expert_rank = i // experts_per_rank
+                empty_expert_local = i % experts_per_rank
+                libshmem_device.signal_op(
+                    barriers_ptr + empty_expert_local * world_size + rank,
+                    1,
+                    libshmem_device.MORI_SIGNAL_SET,
+                    empty_expert_rank,
+                )
+
+
+# ---------------------------------------------------------------------------
+#  Grouped GEMM tile (consumer): one (pid_m, pid_n) tile of the per-expert GEMM
+# ---------------------------------------------------------------------------
+@triton_dist.jit(do_not_specialize=["pid", "num_pid", "M"])
+def tile_kernel_moe_grouped_gemm_nk_const(
+    pid,
+    num_pid,
+    barriers_ptr,  # symm uint64 [experts_per_rank * world_size]
+    a_ptr,  # this rank's received tokens [M, K] (symm output_buf)
+    b_ptr,  # expert weights [experts_per_rank, K, N]
+    c_ptr,  # gemm output [M, N]
+    expert_ids_ptr,  # int32 [num_tiles_m]: local expert id of each m-tile
+    split_size_ptr,  # int32 [experts_per_rank]: tokens per local expert
+    split_size_cum_ptr,  # int32 [num_tiles_m]: token row_begin of the tile's expert
+    tile_num_ptr,  # int32 [num_tiles_m]: #m-tiles of the tile's expert
+    tile_num_cum_ptr,  # int32 [num_tiles_m]: inclusive cumulative #m-tiles
+    M,
+    N: tl.constexpr,
+    K: tl.constexpr,
+    stride_am,
+    stride_ak,
+    stride_be,
+    stride_bn,
+    stride_bk,
+    stride_cm,
+    stride_cn,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    NEED_WAIT: tl.constexpr,
+):
+    num_block_n = tl.cdiv(N, BLOCK_SIZE_N)
+
+    pid_m = pid // num_block_n
+    pid_n = pid % num_block_n
+
+    expert_id = tl.load(expert_ids_ptr + pid_m)
+    split_size = tl.load(split_size_ptr + expert_id)
+    split_size_cum = tl.load(split_size_cum_ptr + pid_m)
+    row_begin = split_size_cum
+    tile_num = tl.load(tile_num_ptr + pid_m)
+    tile_num_cum = tl.load(tile_num_cum_ptr + pid_m)
+    tile_begin = tile_num_cum - tile_num
+    local_pid_m = pid_m - tile_begin
+
+    world_size = dl.num_ranks()
+    thread_idx = tid(0)
+
+    local_pid_m, pid_n = tl.swizzle2d(local_pid_m, pid_n, tile_num, num_block_n, GROUP_SIZE_M)
+
+    # Wait until every source rank has delivered this expert's tokens. Use mori's
+    # signal_wait_until (pairs with the producer's signal_op): on AMD a plain `ld`
+    # with agent scope may never observe a *peer* rank's cross-device signal, and
+    # signal_wait_until's acquire also makes the peer-written tokens visible to the
+    # following tl.load -- matching the validated pattern in the other AMD kernels.
+    if NEED_WAIT:
+        if thread_idx < world_size:
+            libshmem_device.signal_wait_until(
+                barriers_ptr + expert_id * world_size + thread_idx,
+                libshmem_device.MORI_CMP_EQ,
+                1,
+            )
+        __syncthreads()
+
+    row_remain = split_size - local_pid_m * BLOCK_SIZE_M
+
+    offs_bn = (pid_n.to(tl.int64) * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    b_ptrs = (b_ptr + expert_id.to(tl.int64) * stride_be + offs_bn[None, :] * stride_bn + offs_k[:, None] * stride_bk)
+
+    offs_token = row_begin.to(tl.int64) + local_pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    a_ptrs = (a_ptr + offs_token[:, None] * stride_am + offs_k[None, :] * stride_ak)
+
+    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = (c_ptr + offs_token[:, None] * stride_cm + offs_cn[None, :] * stride_cn)
+
+    if row_remain >= BLOCK_SIZE_M:
+        dot_k_const(a_ptrs, b_ptrs, c_ptrs, row_remain, min(BLOCK_SIZE_N, N - pid_n * BLOCK_SIZE_N), K, stride_ak,
+                    stride_bk, BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K, False)
+    elif row_remain > 0:
+        dot_k_const(a_ptrs, b_ptrs, c_ptrs, row_remain, min(BLOCK_SIZE_N, N - pid_n * BLOCK_SIZE_N), K, stride_ak,
+                    stride_bk, BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K, True)
+
+
+# ---------------------------------------------------------------------------
+#  Mega kernel: persistent scheduler over {dispatch tasks} U {gemm tiles}
+# ---------------------------------------------------------------------------
+@triton_dist.jit(do_not_specialize=["M"])
+def mega_kernel_dispatch_token_moe_grouped_gemm(
+    task_counter_ptr,  # global int32 [1], zero init
+
+    # dispatch params
+    recv_buf_offset_per_expert,
+    local_splits_buf,
+    send_buf,
+    output_buf,
+    topk_indices_tensor,
+    token_dst_scatter_idx,
+    num_input_tokens_per_rank,
+    topk: tl.constexpr,
+    hidden_size: tl.constexpr,
+    experts_per_rank: tl.constexpr,
+    WITH_SCATTER_INDICES: tl.constexpr,
+    num_dispatch_tasks: tl.constexpr,
+
+    # grouped gemm params
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    expert_ids_ptr,
+    split_size_ptr,
+    split_size_cum_ptr,
+    tile_num_ptr,
+    tile_num_cum_ptr,
+    num_total_tiles_ptr,  # int32 [1]: total #m-tiles across experts
+    M,
+    N: tl.constexpr,
+    K: tl.constexpr,
+    stride_am,
+    stride_ak,
+    stride_be,
+    stride_bn,
+    stride_bk,
+    stride_cm,
+    stride_cn,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+
+    # synchronization
+    counter_ptr,  # local int32 [num_experts]
+    barriers_ptr,  # symm uint64 [experts_per_rank * world_size]
+    NUM_WARPS: tl.constexpr,
+):
+    task_id = tl.atomic_add(task_counter_ptr, 1)
+    group_gemm_total_tiles_m = tl.load(num_total_tiles_ptr)
+    group_gemm_total_tiles_n = tl.cdiv(N, BLOCK_SIZE_N)
+    group_gemm_tasks = group_gemm_total_tiles_m * group_gemm_total_tiles_n
+    total_tasks = num_dispatch_tasks + group_gemm_tasks
+
+    while task_id < total_tasks:
+        if task_id < num_dispatch_tasks:
+            tile_kernel_dispatch_token_intra_node(
+                task_id,
+                num_dispatch_tasks,
+                counter_ptr,
+                barriers_ptr,
+                recv_buf_offset_per_expert,
+                local_splits_buf,
+                send_buf,
+                output_buf,
+                topk_indices_tensor,
+                token_dst_scatter_idx,
+                num_input_tokens_per_rank,
+                topk,
+                hidden_size,
+                experts_per_rank,
+                WITH_SCATTER_INDICES,
+                NUM_WARPS,
+            )
+        else:
+            tile_kernel_moe_grouped_gemm_nk_const(
+                task_id - num_dispatch_tasks,
+                group_gemm_tasks,
+                barriers_ptr,
+                a_ptr,
+                b_ptr,
+                c_ptr,
+                expert_ids_ptr,
+                split_size_ptr,
+                split_size_cum_ptr,
+                tile_num_ptr,
+                tile_num_cum_ptr,
+                M,
+                N,
+                K,
+                stride_am,
+                stride_ak,
+                stride_be,
+                stride_bn,
+                stride_bk,
+                stride_cm,
+                stride_cn,
+                BLOCK_SIZE_M,
+                BLOCK_SIZE_N,
+                BLOCK_SIZE_K,
+                GROUP_SIZE_M,
+                NEED_WAIT=True,
+            )
+        task_id = tl.atomic_add(task_counter_ptr, 1)
+
+
+# ---------------------------------------------------------------------------
+#  Host orchestration
+# ---------------------------------------------------------------------------
+@dataclass
+class EpA2AFusedContext:
+    group: torch.distributed.ProcessGroup
+    rank: int
+    world_size: int
+    max_tokens: int
+    hidden: int
+    topk: int
+    num_tot_experts: int
+    experts_per_rank: int
+    dtype: torch.dtype
+    weight_dtype: torch.dtype
+    capacity: float
+    cap_tokens: int
+
+    # symmetric (mori) buffers
+    send_buf: torch.Tensor
+    output_buf: torch.Tensor
+    barriers_buf: torch.Tensor
+    combine_in_buf: torch.Tensor
+
+    # scratch (local)
+    task_counter: torch.Tensor
+    expert_counter: torch.Tensor
+    combine_grid_sync: torch.Tensor
+
+    def ep_barrier(self):
+        mori_shmem_barrier_all_on_stream(torch.cuda.current_stream())
+
+    def finalize(self):
+        mori_shmem_free_tensor_sync(self.send_buf)
+        mori_shmem_free_tensor_sync(self.output_buf)
+        mori_shmem_free_tensor_sync(self.barriers_buf)
+        mori_shmem_free_tensor_sync(self.combine_in_buf)
+
+
+def create_ep_a2a_fused_context(
+    group: torch.distributed.ProcessGroup,
+    max_tokens: int,
+    hidden: int,
+    topk: int,
+    num_tot_experts: int,
+    rank: int,
+    world_size: int,
+    dtype: torch.dtype = torch.bfloat16,
+    weight_dtype: torch.dtype = torch.float32,
+    capacity: float = 4.0,
+) -> EpA2AFusedContext:
+    assert num_tot_experts % world_size == 0, "num_tot_experts must be divisible by world_size"
+    experts_per_rank = num_tot_experts // world_size
+    # Upper bound on tokens a single rank can receive (all replicas may land here).
+    cap_tokens = max(int(math.ceil(max_tokens * topk * capacity)), max_tokens)
+
+    send_buf = mori_shmem_create_tensor([max_tokens, hidden], dtype)
+    output_buf = mori_shmem_create_tensor([cap_tokens, hidden], dtype)
+    barriers_buf = mori_shmem_create_tensor([experts_per_rank * world_size], MORI_SHMEM_SIGNAL_DTYPE)
+    barriers_buf.zero_()
+    # gemm2 output / combine source: symmetric so origin ranks can pull rows back.
+    combine_in_buf = mori_shmem_create_tensor([cap_tokens, hidden], dtype)
+
+    device = torch.cuda.current_device()
+    task_counter = torch.zeros([1], dtype=torch.int32, device=device)
+    expert_counter = torch.zeros([num_tot_experts], dtype=torch.int32, device=device)
+    combine_grid_sync = torch.zeros([1], dtype=torch.int32, device=device)
+
+    mori_shmem_barrier_all_on_stream(torch.cuda.current_stream())
+    return EpA2AFusedContext(
+        group=group, rank=rank, world_size=world_size, max_tokens=max_tokens, hidden=hidden, topk=topk,
+        num_tot_experts=num_tot_experts, experts_per_rank=experts_per_rank, dtype=dtype, weight_dtype=weight_dtype,
+        capacity=capacity, cap_tokens=cap_tokens, send_buf=send_buf, output_buf=output_buf,
+        barriers_buf=barriers_buf, combine_in_buf=combine_in_buf, task_counter=task_counter,
+        expert_counter=expert_counter, combine_grid_sync=combine_grid_sync)
+
+
+def _build_gemm_tiling(split_size: torch.Tensor, block_m: int, device):
+    """Build sorted per-m-tile grouped-GEMM metadata from per-expert token counts.
+
+    Returns expert_ids / split_size_cum / tile_num / tile_num_cum (each indexed by
+    global m-tile) plus the total tile count -- the layout the grouped-GEMM tile
+    kernel consumes. Depends on ``block_m``; reused by both dispatch (gemm1) and
+    combine (gemm2) so each can tile with its own BLOCK_M.
+    """
+    split_cpu = split_size.tolist()
+    epr = len(split_cpu)
+    tiles_per_expert = [(s + block_m - 1) // block_m for s in split_cpu]
+    row_begin = [0] * epr
+    acc = 0
+    for g in range(epr):
+        row_begin[g] = acc
+        acc += split_cpu[g]
+    expert_ids, split_size_cum, tile_num, tile_num_cum = [], [], [], []
+    cum_tiles = 0
+    for g in range(epr):
+        cum_tiles += tiles_per_expert[g]
+        for _ in range(tiles_per_expert[g]):
+            expert_ids.append(g)
+            split_size_cum.append(row_begin[g])
+            tile_num.append(tiles_per_expert[g])
+            tile_num_cum.append(cum_tiles)
+    total_tiles = int(sum(tiles_per_expert))
+
+    def _i32(lst):
+        if len(lst) == 0:
+            return torch.zeros([1], dtype=torch.int32, device=device)
+        return torch.tensor(lst, dtype=torch.int32, device=device)
+
+    return dict(
+        expert_ids=_i32(expert_ids),
+        split_size_cum=_i32(split_size_cum),
+        tile_num=_i32(tile_num),
+        tile_num_cum=_i32(tile_num_cum),
+        total_tiles=torch.tensor([total_tiles], dtype=torch.int32, device=device),
+        total_tiles_int=total_tiles,
+    )
+
+
+def _build_dispatch_metadata(ctx: EpA2AFusedContext, topk_indices: torch.Tensor, block_m: int):
+    """Compute, in torch, everything the fused kernel needs that is cheaper /
+    safer to derive on the host: the cross-rank split exchange, the destination
+    recv offsets, and the grouped-GEMM tiling metadata for this rank's experts.
+    """
+    device = topk_indices.device
+    ws = ctx.world_size
+    epr = ctx.experts_per_rank
+    num_experts = ctx.num_tot_experts
+
+    # local_splits[e] = #tokens this rank routes to global expert e
+    local_splits = torch.bincount(topk_indices.reshape(-1), minlength=num_experts).to(torch.int32)[:num_experts]
+
+    # all_gather -> full_splits[s, e]
+    full_splits = torch.empty((ws, num_experts), dtype=torch.int32, device=device)
+    torch.distributed.all_gather_into_tensor(full_splits, local_splits, group=ctx.group)
+
+    # counts[dst_rank, expert_local, src_rank]; recall e = dst_rank * epr + expert_local
+    counts = full_splits.view(ws, ws, epr).permute(1, 2, 0).contiguous()  # [dst, g, src]
+    flat = counts.view(ws, epr * ws)
+    recv_buf_offset = (flat.cumsum(dim=1) - flat).view(ws, epr, ws).to(torch.int32).contiguous()
+    num_recv_tokens_per_rank = flat.sum(dim=1).to(torch.int32)  # [ws]
+    num_input_tokens_per_rank = (full_splits.sum(dim=1) // ctx.topk).to(torch.int32)  # [ws]
+
+    M_local = int(num_recv_tokens_per_rank[ctx.rank].item())
+    split_size = counts[ctx.rank].sum(dim=1).to(torch.int32)  # [epr]
+
+    meta = dict(
+        local_splits=local_splits,
+        recv_buf_offset=recv_buf_offset,
+        num_input_tokens_per_rank=num_input_tokens_per_rank,
+        num_recv_tokens_per_rank=num_recv_tokens_per_rank,
+        M_local=M_local,
+        split_size=split_size,
+    )
+    meta.update(_build_gemm_tiling(split_size, block_m, device))
+    return meta
+
+
+def fused_dispatch_token_moe_grouped_gemm(
+    ctx: EpA2AFusedContext,
+    input: torch.Tensor,  # [num_tokens, hidden] this rank's tokens
+    topk_indices: torch.Tensor,  # [num_tokens, topk] int32 (global expert ids)
+    gemm_weight: torch.Tensor,  # [experts_per_rank, hidden, N]
+    num_sms: int = 64,
+    num_dispatch_tasks: int = 20,
+    BLOCK_SIZE_M: int = 128,
+    BLOCK_SIZE_N: int = 128,
+    BLOCK_SIZE_K: int = 64,
+    GROUP_SIZE_M: int = 4,
+    num_warps: int = 8,
+    num_stages: int = 2,
+    gemm_output: Optional[torch.Tensor] = None,
+):
+    """Run fused dispatch + grouped GEMM. Returns ``(gemm_output[M, N], meta)``.
+
+    ``meta`` carries the layout (recv offsets, scatter idx, per-rank token
+    counts) needed by a subsequent combine.
+    """
+    assert input.is_contiguous() and input.dtype == ctx.dtype
+    assert topk_indices.dtype == torch.int32 and topk_indices.shape[1] == ctx.topk
+    num_tokens, hidden = input.shape
+    assert hidden == ctx.hidden and num_tokens <= ctx.max_tokens
+    G, K, N = gemm_weight.shape
+    assert G == ctx.experts_per_rank and K == ctx.hidden
+    # Drop tokens are unsupported: every (token, slot) must map to a real expert.
+    assert bool(((topk_indices >= 0) & (topk_indices < ctx.num_tot_experts)).all()), \
+        "topk_indices out of [0, num_tot_experts); drop tokens are not supported"
+
+    meta = _build_dispatch_metadata(ctx, topk_indices, BLOCK_SIZE_M)
+    M = meta["M_local"]
+    device = input.device
+    if M > ctx.cap_tokens:
+        raise RuntimeError(
+            f"received M={M} routed tokens > cap_tokens={ctx.cap_tokens}; increase `capacity` or `max_tokens`")
+    num_sms = min(num_sms, torch.cuda.get_device_properties(device).multi_processor_count)
+
+    # stage this rank's tokens into the symmetric send buffer (putmem source)
+    ctx.send_buf[:num_tokens].copy_(input)
+
+    token_dst_scatter_idx = torch.empty((num_tokens, ctx.topk), dtype=torch.int32, device=device)
+
+    if gemm_output is None:
+        gemm_output = torch.empty([max(M, 1), N], dtype=ctx.dtype, device=device)
+    else:
+        assert gemm_output.shape[0] >= M and gemm_output.shape[1] == N
+
+    # reset per-call state
+    ctx.task_counter.zero_()
+    ctx.expert_counter.zero_()
+    ctx.barriers_buf.zero_()
+    recv_buf_offset = meta["recv_buf_offset"].clone()  # consumed (atomically bumped) by the kernel
+    ctx.ep_barrier()
+
+    # Do NOT early-return when M == 0: this rank may still own tokens to *send*
+    # to other ranks (producer role) and must emit empty-expert pre-signals, so
+    # skipping the launch would hang peers. M == 0 just yields 0 GEMM tiles.
+    grid = (num_sms, )
+    mega_kernel_dispatch_token_moe_grouped_gemm[grid](
+        ctx.task_counter,
+        recv_buf_offset,
+        meta["local_splits"],
+        ctx.send_buf,
+        ctx.output_buf,
+        topk_indices,
+        token_dst_scatter_idx,
+        meta["num_input_tokens_per_rank"],
+        ctx.topk,
+        ctx.hidden,
+        ctx.experts_per_rank,
+        False,  # WITH_SCATTER_INDICES (compute in-kernel)
+        num_dispatch_tasks,
+        ctx.output_buf,  # a_ptr: GEMM reads this rank's received tokens
+        gemm_weight,
+        gemm_output,
+        meta["expert_ids"],
+        meta["split_size"],
+        meta["split_size_cum"],
+        meta["tile_num"],
+        meta["tile_num_cum"],
+        meta["total_tiles"],
+        M,
+        N,
+        K,
+        ctx.output_buf.stride(0),
+        ctx.output_buf.stride(1),
+        gemm_weight.stride(0),
+        gemm_weight.stride(2),
+        gemm_weight.stride(1),
+        gemm_output.stride(0),
+        gemm_output.stride(1),
+        BLOCK_SIZE_M,
+        BLOCK_SIZE_N,
+        BLOCK_SIZE_K,
+        GROUP_SIZE_M,
+        ctx.expert_counter,
+        ctx.barriers_buf,
+        num_warps,
+        num_warps=num_warps,
+        num_stages=num_stages,
+    )
+
+    meta["token_dst_scatter_idx"] = token_dst_scatter_idx
+    ctx.ep_barrier()
+    return gemm_output[:M], meta
+
+
+# ===========================================================================
+#  Combine: grouped GEMM (gemm2 / down-proj) fused with gather + topk reduce
+# ===========================================================================
+@triton_dist.jit(do_not_specialize=["pid", "num_pid"])
+def tile_kernel_gather_combine_token_intra_node(
+    pid,
+    num_pid,
+    num_input_tokens_per_rank,  # int32 [world_size]
+    input_buf,  # symm: per-rank gemm2 output rows [cap_tokens, hidden] (pull source)
+    output_buf,  # local: combined output [num_tokens, hidden]
+    topk_weights,  # local fp32 [num_tokens, topk] (routing weights) or dummy
+    topk_indices_buf,  # int32 [num_tokens, topk]
+    token_dst_scatter_idx,  # int32 [num_tokens, topk]
+    topk: tl.constexpr,
+    hidden_size: tl.constexpr,
+    experts_per_rank: tl.constexpr,
+    HAS_GATE: tl.constexpr,
+    num_warps: tl.constexpr,
+):
+    """Gather each origin token's topk expert outputs from the expert ranks (via
+    ``symm_at`` peer pointers) and write the (weighted) sum. One warp per token,
+    lanes stride the hidden dim. Relies on the caller having performed a cross-rank
+    barrier so every ``input_buf`` row is already computed and globally visible.
+    """
+    WARP_SIZE: tl.constexpr = 64
+    out_dtype = output_buf.dtype.element_ty
+    rank = dl.rank()
+    world_size = dl.num_ranks()
+    thread_idx = tid(0)
+    lane_id = thread_idx % WARP_SIZE
+    warp_id = thread_idx // WARP_SIZE
+    total_warps = num_warps * num_pid
+    global_warp_id = pid * num_warps + warp_id
+
+    num_tokens = tl.load(num_input_tokens_per_rank + rank)
+
+    for token_idx in range(global_warp_id, num_tokens, total_warps):
+        for i in range(lane_id, hidden_size, WARP_SIZE):
+            acc = tl.zeros((), dtype=tl.float32)
+            for j in range(topk):
+                expert_idx = ld(topk_indices_buf + token_idx * topk + j)
+                expert_rank = expert_idx // experts_per_rank
+                if expert_rank < world_size:
+                    scatter_idx = ld(token_dst_scatter_idx + token_idx * topk + j)
+                    remote_ptr = dl.symm_at(input_buf, expert_rank)
+                    # cross-device read of a peer's HBM: use system-scope acquire so the
+                    # value written by the peer's gemm2 (before barrier_all) is observed.
+                    val = ld(remote_ptr + scatter_idx.to(tl.int64) * hidden_size + i, scope="system",
+                             semantic="acquire").to(tl.float32)
+                    if HAS_GATE:
+                        w = tl.load(topk_weights + token_idx * topk + j)
+                        acc += w * val
+                    else:
+                        acc += val
+            st(output_buf + token_idx.to(tl.int64) * hidden_size + i, acc.to(out_dtype))
+
+
+@triton_dist.jit(do_not_specialize=["M"])
+def mega_kernel_moe_grouped_gemm_combine_token(
+    # grouped gemm (gemm2 / down-proj) params
+    a_ptr,  # local: gemm2 input [M, K] (dispatched-layout activation)
+    b_ptr,  # expert weights [experts_per_rank, K, N]
+    c_ptr,  # symm: gemm2 output / combine source [cap_tokens, N]
+    expert_ids_ptr,
+    split_size_ptr,
+    split_size_cum_ptr,
+    tile_num_ptr,
+    tile_num_cum_ptr,
+    num_total_tiles_ptr,
+    M,
+    N: tl.constexpr,
+    K: tl.constexpr,
+    stride_am,
+    stride_ak,
+    stride_be,
+    stride_bn,
+    stride_bk,
+    stride_cm,
+    stride_cn,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+
+    # combine params
+    num_input_tokens_per_rank,  # int32 [world_size]
+    output_buf,  # local: combined output [num_tokens, N]
+    topk_weights,  # local fp32 [num_tokens, topk] or dummy
+    topk_indices_buf,  # int32 [num_tokens, topk]
+    token_dst_scatter_idx,  # int32 [num_tokens, topk]
+    topk: tl.constexpr,
+    experts_per_rank: tl.constexpr,
+    HAS_GATE: tl.constexpr,
+
+    # synchronization
+    barriers_ptr,  # symm uint64 (unused here; NEED_WAIT=False) -- valid placeholder
+    grid_sync_counter,  # local int32 [1]
+    NUM_WARPS: tl.constexpr,
+):
+    """Serial-mode combine mega kernel (mirrors NVIDIA non-scatter path):
+
+      phase 1: every CTA strides over the grouped-GEMM(2) tiles, writing the
+               down-proj output into the symmetric ``c_ptr``.
+      barrier: grid barrier + cross-rank ``barrier_all`` so all ranks' rows are
+               written and visible.
+      phase 2: gather + topk-weighted reduce into ``output_buf``.
+    """
+    sm_id = tl.program_id(0)
+    num_sms = tl.num_programs(0)
+    group_gemm_total_tiles_m = tl.load(num_total_tiles_ptr)
+    group_gemm_total_tiles_n = tl.cdiv(N, BLOCK_SIZE_N)
+    group_gemm_tasks = group_gemm_total_tiles_m * group_gemm_total_tiles_n
+
+    for task_id in range(sm_id, group_gemm_tasks, num_sms):
+        tile_kernel_moe_grouped_gemm_nk_const(
+            task_id,
+            group_gemm_tasks,
+            barriers_ptr,
+            a_ptr,
+            b_ptr,
+            c_ptr,
+            expert_ids_ptr,
+            split_size_ptr,
+            split_size_cum_ptr,
+            tile_num_ptr,
+            tile_num_cum_ptr,
+            M,
+            N,
+            K,
+            stride_am,
+            stride_ak,
+            stride_be,
+            stride_bn,
+            stride_bk,
+            stride_cm,
+            stride_cn,
+            BLOCK_SIZE_M,
+            BLOCK_SIZE_N,
+            BLOCK_SIZE_K,
+            GROUP_SIZE_M,
+            NEED_WAIT=False,
+        )
+
+    # all local tiles done -> sync the grid, then sync all ranks (so every
+    # rank's gemm2 output is complete and globally visible), then sync the grid.
+    barrier_on_this_grid(grid_sync_counter, False)
+    if sm_id == 0:
+        libshmem_device.barrier_all_block()
+    barrier_on_this_grid(grid_sync_counter, False)
+
+    tile_kernel_gather_combine_token_intra_node(
+        sm_id,
+        num_sms,
+        num_input_tokens_per_rank,
+        c_ptr,
+        output_buf,
+        topk_weights,
+        topk_indices_buf,
+        token_dst_scatter_idx,
+        topk,
+        N,
+        experts_per_rank,
+        HAS_GATE,
+        NUM_WARPS,
+    )
+
+
+def fused_group_gemm_combine_token(
+    ctx: EpA2AFusedContext,
+    gemm_input: torch.Tensor,  # [M, K2] dispatched-layout activation (e.g. act(gemm1 out))
+    gemm_weight: torch.Tensor,  # [experts_per_rank, K2, N2] (N2 must == ctx.hidden)
+    meta: dict,  # layout descriptor returned by fused_dispatch_token_moe_grouped_gemm
+    topk_indices: torch.Tensor,  # [num_tokens, topk] int32 (same as dispatch)
+    topk_weights: Optional[torch.Tensor] = None,  # [num_tokens, topk] fp32 routing weights
+    num_sms: int = 64,
+    BLOCK_SIZE_M: int = 128,
+    BLOCK_SIZE_N: int = 128,
+    BLOCK_SIZE_K: int = 64,
+    GROUP_SIZE_M: int = 4,
+    num_warps: int = 8,
+    num_stages: int = 2,
+    combine_output: Optional[torch.Tensor] = None,
+):
+    """Fused gemm2 + combine. Returns ``combined_out[num_tokens, N2]``."""
+    M = meta["M_local"]
+    num_tokens = topk_indices.shape[0]
+    G, K2, N2 = gemm_weight.shape
+    assert G == ctx.experts_per_rank
+    assert N2 == ctx.hidden, "combine maps expert outputs back to `hidden`; expected N2 == ctx.hidden"
+    assert topk_indices.dtype == torch.int32 and topk_indices.shape[1] == ctx.topk
+    device = gemm_input.device
+    if M > ctx.cap_tokens:
+        raise RuntimeError(
+            f"received M={M} routed tokens > cap_tokens={ctx.cap_tokens}; increase `capacity` or `max_tokens`")
+    num_sms = min(num_sms, torch.cuda.get_device_properties(device).multi_processor_count)
+
+    has_gate = topk_weights is not None
+    if has_gate:
+        assert topk_weights.shape == (num_tokens, ctx.topk)
+        topk_weights = topk_weights.to(torch.float32).contiguous()
+    else:
+        topk_weights = torch.empty((1, ), dtype=torch.float32, device=device)
+
+    token_dst_scatter_idx = meta["token_dst_scatter_idx"]
+    tiling = _build_gemm_tiling(meta["split_size"], BLOCK_SIZE_M, device)
+
+    if combine_output is None:
+        combine_output = torch.empty([num_tokens, N2], dtype=ctx.dtype, device=device)
+    else:
+        assert combine_output.shape == (num_tokens, N2)
+
+    ctx.combine_grid_sync.zero_()
+    ctx.ep_barrier()
+
+    # Do NOT early-return when M == 0: every rank must enter the kernel's
+    # device-side barrier_all and still gather its own origin tokens from peers.
+    assert gemm_input.shape == (M, K2) and gemm_input.is_contiguous()
+    c_buf = ctx.combine_in_buf  # [cap_tokens, hidden]
+
+    grid = (num_sms, )
+    mega_kernel_moe_grouped_gemm_combine_token[grid](
+        gemm_input,
+        gemm_weight,
+        c_buf,
+        tiling["expert_ids"],
+        meta["split_size"],
+        tiling["split_size_cum"],
+        tiling["tile_num"],
+        tiling["tile_num_cum"],
+        tiling["total_tiles"],
+        M,
+        N2,
+        K2,
+        gemm_input.stride(0),
+        gemm_input.stride(1),
+        gemm_weight.stride(0),
+        gemm_weight.stride(2),
+        gemm_weight.stride(1),
+        c_buf.stride(0),
+        c_buf.stride(1),
+        BLOCK_SIZE_M,
+        BLOCK_SIZE_N,
+        BLOCK_SIZE_K,
+        GROUP_SIZE_M,
+        meta["num_input_tokens_per_rank"],
+        combine_output,
+        topk_weights,
+        topk_indices,
+        token_dst_scatter_idx,
+        ctx.topk,
+        ctx.experts_per_rank,
+        has_gate,
+        ctx.barriers_buf,
+        ctx.combine_grid_sync,
+        num_warps,
+        num_warps=num_warps,
+        num_stages=num_stages,
+    )
+
+    ctx.ep_barrier()
+    return combine_output

--- a/python/triton_dist/kernels/amd/ep_all2all_fused.py
+++ b/python/triton_dist/kernels/amd/ep_all2all_fused.py
@@ -263,11 +263,22 @@ def tile_kernel_moe_grouped_gemm_nk_const(
 
     local_pid_m, pid_n = tl.swizzle2d(local_pid_m, pid_n, tile_num, num_block_n, GROUP_SIZE_M)
 
-    # Wait until every source rank has delivered this expert's tokens. Use mori's
-    # signal_wait_until (pairs with the producer's signal_op): on AMD a plain `ld`
-    # with agent scope may never observe a *peer* rank's cross-device signal, and
-    # signal_wait_until's acquire also makes the peer-written tokens visible to the
-    # following tl.load -- matching the validated pattern in the other AMD kernels.
+    # Wait until every source rank has delivered this expert's tokens, then issue a
+    # system-scope fence before reading the peer-written rows.
+    #
+    # IMPORTANT: mori's signal_wait_until is a *relaxed* system wait
+    # (ShmemTypeWaitUntilEquals -> while(AtomicLoadRelaxedSystem(addr) != val){}); it
+    # does NOT carry acquire semantics, so it alone does not make the peer-written
+    # `output_buf` rows visible to the following tl.load. NVIDIA uses ld_acquire here;
+    # the mori port dropped the acquire, so we restore consumer-side visibility with an
+    # explicit system fence after the wait. __syncthreads() only orders within the block
+    # and does not invalidate system-scope (peer-GPU) caches.
+    #
+    # We use libshmem_device.fence() (= __threadfence_system, a seq_cst system fence that
+    # subsumes acquire) on purpose: the dedicated language_extra.fence(scope="system")
+    # lowers to `fence syncscope("system") ...`, an AMDGPU-unsupported scope string that
+    # fails to compile on gfx942 ("Unsupported atomic synchronization scope"). The HIP
+    # __threadfence_system builtin lowers to the correct system-scope fence.
     if NEED_WAIT:
         if thread_idx < world_size:
             libshmem_device.signal_wait_until(
@@ -276,6 +287,7 @@ def tile_kernel_moe_grouped_gemm_nk_const(
                 1,
             )
         __syncthreads()
+        libshmem_device.fence()
 
     row_remain = split_size - local_pid_m * BLOCK_SIZE_M
 
@@ -1161,6 +1173,11 @@ def fused_group_gemm_combine_token(
     assert N2 == ctx.hidden, "combine maps expert outputs back to `hidden`; expected N2 == ctx.hidden"
     assert gemm_weight.dtype == ctx.dtype, "expert weights must match the activation dtype (ctx.dtype)"
     assert topk_indices.dtype == torch.int32 and topk_indices.shape[1] == ctx.topk and topk_indices.is_contiguous()
+    # Validate the routing combine will gather on: the kernel computes expert_rank = expert_idx // epr
+    # and reads peer buffers via symm_at(expert_rank), so an out-of-range / negative id would index an
+    # invalid peer rank or address. Mirror the dispatch boundary check; per-rank local (see dispatch docstring).
+    assert bool(((topk_indices >= 0) & (topk_indices < ctx.num_tot_experts)).all()), \
+        "topk_indices out of range [0, num_tot_experts)"
     device = gemm_input.device
     # Global capacity check (see fused_dispatch_token_moe_grouped_gemm): raise on every rank together.
     max_recv = int(meta["num_recv_tokens_per_rank"].max().item())
@@ -1191,7 +1208,12 @@ def fused_group_gemm_combine_token(
     if combine_output is None:
         combine_output = torch.empty([num_tokens, N2], dtype=ctx.dtype, device=device)
     else:
+        # The gather kernel writes rows linearly (st(output_buf + token_idx*hidden + i), no strides),
+        # so a non-contiguous / wrong-dtype / wrong-device buffer would be written with the wrong layout.
         assert combine_output.shape == (num_tokens, N2)
+        assert combine_output.is_contiguous(), "combine_output must be contiguous"
+        assert combine_output.dtype == ctx.dtype, "combine_output dtype must match ctx.dtype"
+        assert combine_output.device == device, "combine_output must be on the same device as gemm_input"
 
     ctx.combine_grid_sync.zero_()
     ctx.ep_barrier()

--- a/python/triton_dist/kernels/amd/ep_all2all_fused.py
+++ b/python/triton_dist/kernels/amd/ep_all2all_fused.py
@@ -38,8 +38,10 @@ and synchronization use mori_shmem device primitives via ``libshmem_device``
 symmetric buffers come from ``mori_shmem_create_tensor`` and a per-expert
 ``MORI_SHMEM_SIGNAL_DTYPE`` (uint64) barrier; the wavefront width is 64 and
 grouped-GEMM tiles are plain pointer-arithmetic ``tl.dot``. The cross-rank split
-exchange and grouped-GEMM tiling metadata are computed on the host in plain torch
-(run once per call); the data plane stays inside the fused kernels.
+exchange and grouped-GEMM tiling metadata are built on-device by default (kernels
+``kernel_build_fused_dispatch_metadata`` / ``kernel_build_gemm_tiling``); pass
+``use_device_metadata=False`` to fall back to the host torch path. The data plane
+stays inside the fused kernels.
 """
 
 import math
@@ -61,6 +63,8 @@ from triton_dist.language.extra.hip.language_extra import (
     atomic_add,
     atomic_add_per_warp,
 )
+from triton_dist.language.extra.language_extra import threads_per_warp
+from triton_dist.kernels.amd.ep_a2a import bincount
 from triton_dist.kernels.amd.common_ops import barrier_on_this_grid
 from triton_dist.utils import (
     MORI_SHMEM_SIGNAL_DTYPE,
@@ -425,11 +429,16 @@ class EpA2AFusedContext:
     output_buf: torch.Tensor
     barriers_buf: torch.Tensor
     combine_in_buf: torch.Tensor
+    # symmetric buffers for the device-side metadata all-gather
+    local_splits_buf: torch.Tensor
+    full_splits_buf: torch.Tensor
+    splits_signal_buf: torch.Tensor
 
     # scratch (local)
     task_counter: torch.Tensor
     expert_counter: torch.Tensor
     combine_grid_sync: torch.Tensor
+    meta_grid_sync: torch.Tensor
 
     def ep_barrier(self):
         mori_shmem_barrier_all_on_stream(torch.cuda.current_stream())
@@ -439,6 +448,9 @@ class EpA2AFusedContext:
         mori_shmem_free_tensor_sync(self.output_buf)
         mori_shmem_free_tensor_sync(self.barriers_buf)
         mori_shmem_free_tensor_sync(self.combine_in_buf)
+        mori_shmem_free_tensor_sync(self.local_splits_buf)
+        mori_shmem_free_tensor_sync(self.full_splits_buf)
+        mori_shmem_free_tensor_sync(self.splits_signal_buf)
 
 
 def create_ep_a2a_fused_context(
@@ -465,18 +477,28 @@ def create_ep_a2a_fused_context(
     # gemm2 output / combine source: symmetric so origin ranks can pull rows back.
     combine_in_buf = mori_shmem_create_tensor([cap_tokens, hidden], dtype)
 
+    # device-side metadata all-gather buffers (symmetric)
+    local_splits_buf = mori_shmem_create_tensor([num_tot_experts], torch.int32)
+    local_splits_buf.zero_()
+    full_splits_buf = mori_shmem_create_tensor([world_size, num_tot_experts], torch.int32)
+    full_splits_buf.zero_()
+    splits_signal_buf = mori_shmem_create_tensor([world_size], MORI_SHMEM_SIGNAL_DTYPE)
+    splits_signal_buf.zero_()
+
     device = torch.cuda.current_device()
     task_counter = torch.zeros([1], dtype=torch.int32, device=device)
     expert_counter = torch.zeros([num_tot_experts], dtype=torch.int32, device=device)
     combine_grid_sync = torch.zeros([1], dtype=torch.int32, device=device)
+    meta_grid_sync = torch.zeros([1], dtype=torch.int32, device=device)
 
     mori_shmem_barrier_all_on_stream(torch.cuda.current_stream())
     return EpA2AFusedContext(
         group=group, rank=rank, world_size=world_size, max_tokens=max_tokens, hidden=hidden, topk=topk,
         num_tot_experts=num_tot_experts, experts_per_rank=experts_per_rank, dtype=dtype, weight_dtype=weight_dtype,
         capacity=capacity, cap_tokens=cap_tokens, send_buf=send_buf, output_buf=output_buf,
-        barriers_buf=barriers_buf, combine_in_buf=combine_in_buf, task_counter=task_counter,
-        expert_counter=expert_counter, combine_grid_sync=combine_grid_sync)
+        barriers_buf=barriers_buf, combine_in_buf=combine_in_buf, local_splits_buf=local_splits_buf,
+        full_splits_buf=full_splits_buf, splits_signal_buf=splits_signal_buf, task_counter=task_counter,
+        expert_counter=expert_counter, combine_grid_sync=combine_grid_sync, meta_grid_sync=meta_grid_sync)
 
 
 def _build_gemm_tiling(split_size: torch.Tensor, block_m: int, device):
@@ -518,7 +540,6 @@ def _build_gemm_tiling(split_size: torch.Tensor, block_m: int, device):
         tile_num=_i32(tile_num),
         tile_num_cum=_i32(tile_num_cum),
         total_tiles=torch.tensor([total_tiles], dtype=torch.int32, device=device),
-        total_tiles_int=total_tiles,
     )
 
 
@@ -531,6 +552,11 @@ def _build_dispatch_metadata(ctx: EpA2AFusedContext, topk_indices: torch.Tensor,
     ws = ctx.world_size
     epr = ctx.experts_per_rank
     num_experts = ctx.num_tot_experts
+
+    # Validate at this public-boundary entry, consistently with the device path (torch.bincount
+    # would raise on negatives but silently drop over-range ids via the [:num_experts] slice).
+    assert bool(((topk_indices >= 0) & (topk_indices < num_experts)).all()), \
+        "topk_indices out of range [0, num_tot_experts); drop-token / invalid ids are not supported"
 
     # local_splits[e] = #tokens this rank routes to global expert e
     local_splits = torch.bincount(topk_indices.reshape(-1), minlength=num_experts).to(torch.int32)[:num_experts]
@@ -556,8 +582,257 @@ def _build_dispatch_metadata(ctx: EpA2AFusedContext, topk_indices: torch.Tensor,
         num_recv_tokens_per_rank=num_recv_tokens_per_rank,
         M_local=M_local,
         split_size=split_size,
+        metadata_backend="host",
     )
     meta.update(_build_gemm_tiling(split_size, block_m, device))
+    return meta
+
+
+# ---------------------------------------------------------------------------
+#  Device-side metadata kernels (replace the host torch path above)
+# ---------------------------------------------------------------------------
+@triton_dist.jit
+def kernel_build_fused_dispatch_metadata(
+    local_splits_buf,  # symm int32 [num_experts]: this rank's per-global-expert token count
+    full_splits_buf,  # symm int32 [world_size, num_experts]: all-gather destination
+    splits_signal_buf,  # symm signal [world_size]: per-source all-gather done flag
+    recv_buf_offset_per_expert,  # int32 [world_size, experts_per_rank, world_size] (out)
+    num_input_tokens_per_rank,  # int32 [world_size] (out)
+    num_recv_tokens_per_rank,  # int32 [world_size] (out)
+    split_size,  # int32 [experts_per_rank] (out, MUST be zeroed on host: accumulated via atomic_add)
+    grid_sync_counter,  # int32 [1]: grid barrier workspace (single slot, reused)
+    experts_per_rank: tl.constexpr,
+    topk: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,  # power-of-two >= num_experts
+    num_warps: tl.constexpr,
+):
+    """Device equivalent of ``_build_dispatch_metadata`` (intra-node).
+
+    Mirrors the validated AMD pattern in ``kernel_get_ag_splits_and_recv_offset_intra_node``
+    (``ep_a2a_intra_node.py``) -- the AMD/mori port of NVIDIA's
+    ``kernel_get_ag_splits_and_recv_offset`` -- and additionally accumulates this rank's
+    per-local-expert ``split_size``. Produces a byte-identical layout to the host path
+    (``recv_buf_offset`` ordered g-major / src-minor; ``num_input = sum // topk``).
+    """
+    rank = dl.rank()
+    world_size = dl.num_ranks()
+    pid = tl.program_id(0)
+    num_pid = tl.num_programs(0)
+    num_experts = experts_per_rank * world_size
+    elem_size = tl.constexpr(local_splits_buf.dtype.element_ty.primitive_bitwidth) // 8
+    nbytes = num_experts * elem_size
+    threads_per_block = num_warps * threads_per_warp()
+    thread_idx = tid(0)
+
+    # phase 1: all-gather local_splits -> full_splits_buf[rank] on every peer (incl. self)
+    for remote_rank in range(pid, world_size, num_pid):
+        libshmem_device.putmem_signal_nbi_block(
+            full_splits_buf + rank * num_experts,
+            local_splits_buf,
+            nbytes,
+            splits_signal_buf + rank,
+            1,
+            libshmem_device.MORI_SIGNAL_SET,
+            remote_rank,
+        )
+
+    # ensure all all-gather traffic is globally visible before any consumer reads
+    barrier_on_this_grid(grid_sync_counter, False)
+    if pid == 0:
+        libshmem_device.barrier_all_block()
+    barrier_on_this_grid(grid_sync_counter, False)
+
+    offs = tl.arange(0, BLOCK_SIZE)
+    expert_mask = offs < num_experts
+
+    # phase 2: scatter full_splits[target, e] -> recv_buf_offset[e//epr, e%epr, target];
+    #          compute num_input_tokens[target]; accumulate this rank's split_size.
+    for target_rank in range(pid, world_size, num_pid):
+        token = dl.wait(splits_signal_buf + target_rank, 1, "sys", "acquire")
+        full_splits_buf = dl.consume_token(full_splits_buf, token)
+        __syncthreads()
+        for expert_idx in range(thread_idx, num_experts, threads_per_block):
+            val = ld(full_splits_buf + target_rank * num_experts + expert_idx, semantic="acquire")
+            ep_rank = expert_idx // experts_per_rank
+            expert_idx_intra_rank = expert_idx % experts_per_rank
+            st(
+                recv_buf_offset_per_expert + ep_rank * experts_per_rank * world_size +
+                expert_idx_intra_rank * world_size + target_rank, val, semantic="release")
+            if ep_rank == rank:
+                atomic_add(split_size + expert_idx_intra_rank, val, scope="agent", semantic="relaxed")
+        __syncthreads()
+        splits_cur_rank = tl.load(full_splits_buf + target_rank * num_experts + offs, mask=expert_mask, other=0,
+                                  volatile=True)
+        total_topk_token_cur_rank = tl.sum(splits_cur_rank)
+        tl.store(num_input_tokens_per_rank + target_rank, total_topk_token_cur_rank // topk)
+        __syncthreads()
+
+    # split_size (atomic) and recv_buf_offset (raw counts) are fully written across all pids
+    barrier_on_this_grid(grid_sync_counter, False)
+
+    # phase 3: per ep_rank, exclusive prefix sum over [experts_per_rank * world_size];
+    #          num_recv_tokens_per_rank[ep_rank] = total.
+    for ep_rank in range(pid, world_size, num_pid):
+        splits_cur = tl.load(recv_buf_offset_per_expert + ep_rank * num_experts + offs, mask=expert_mask, other=0,
+                             volatile=True)
+        recv_tokens = tl.sum(splits_cur)
+        cumsum_exclude = tl.cumsum(splits_cur) - splits_cur
+        tl.store(recv_buf_offset_per_expert + ep_rank * num_experts + offs, cumsum_exclude, mask=expert_mask)
+        tl.store(num_recv_tokens_per_rank + ep_rank, recv_tokens)
+    __syncthreads()
+
+
+@triton.jit
+def _element_at(x: tl.tensor, idx) -> tl.tensor:
+    return tl.sum(tl.where(tl.arange(0, x.numel) == idx, x, 0))
+
+
+@triton.jit
+def kernel_build_gemm_tiling(
+    split_size_ptr,  # int32 [E]: per-local-expert token counts
+    split_size_cum_ptr,  # int32 [num_tiles] (out): row_begin of each m-tile's expert
+    expert_ids_ptr,  # int32 [num_tiles] (out): local expert id of each m-tile
+    tile_num_ptr,  # int32 [num_tiles] (out): #m-tiles of each m-tile's expert
+    tile_num_cum_ptr,  # int32 [num_tiles] (out): inclusive cumulative #m-tiles
+    num_tiles_total_ptr,  # int32 [1] (out)
+    E: tl.constexpr,
+    E_PAD: tl.constexpr,  # power-of-two >= E
+    BLOCK_SIZE_M: tl.constexpr,
+    NUM_SMS: tl.constexpr,
+):
+    """Device port of NVIDIA ``build_block_row_idx_info_kernel`` (``nvidia/group_gemm.py``).
+
+    Expands per-expert token counts into the per-m-tile grouped-GEMM metadata consumed by
+    ``tile_kernel_moe_grouped_gemm_nk_const`` -- the device equivalent of ``_build_gemm_tiling``.
+    """
+    sm_id = tl.program_id(0)
+    idx = tl.arange(0, E_PAD)
+    mask = idx < E
+    row_splits = tl.load(split_size_ptr + idx, mask=mask, other=0)
+    row_cumsums = tl.cumsum(row_splits, axis=0)
+    row_offs = row_cumsums - row_splits
+    tiles_splits = tl.cdiv(row_splits, BLOCK_SIZE_M)
+    tiles_cumsum = tl.cumsum(tiles_splits, axis=0)
+    num_tiles_total = tl.sum(tiles_splits, axis=0)
+
+    if sm_id == 0:
+        tl.store(num_tiles_total_ptr, num_tiles_total)
+
+    for pid in range(sm_id, num_tiles_total, NUM_SMS):
+        if pid < num_tiles_total:
+            expert_idx = tl.argmax((pid < tiles_cumsum).to(tl.int1), axis=0, tie_break_left=True)
+            if expert_idx == 0:
+                row_offset = 0
+                tile_split = _element_at(tiles_splits, 0)
+                tile_cumsum = tile_split
+            else:
+                row_offset = _element_at(row_offs, expert_idx)
+                tile_split = _element_at(tiles_splits, expert_idx)
+                tile_cumsum = _element_at(tiles_cumsum, expert_idx)
+            tl.store(expert_ids_ptr + pid, expert_idx)
+            tl.store(split_size_cum_ptr + pid, row_offset)
+            tl.store(tile_num_ptr + pid, tile_split)
+            tl.store(tile_num_cum_ptr + pid, tile_cumsum)
+
+
+def _build_gemm_tiling_device(split_size: torch.Tensor, block_m: int, epr: int, device, M_local: int, num_sms: int = 64):
+    """Device-kernel version of ``_build_gemm_tiling`` (same dict layout)."""
+    # An expert contributes at most cdiv(tokens, block_m) tiles; the +epr bound covers
+    # the partial tile of every expert, so M_grid is a safe upper bound on total tiles.
+    M_grid = max((M_local + block_m - 1) // block_m + epr, 1)
+    expert_ids = torch.zeros([M_grid], dtype=torch.int32, device=device)
+    split_size_cum = torch.zeros([M_grid], dtype=torch.int32, device=device)
+    tile_num = torch.zeros([M_grid], dtype=torch.int32, device=device)
+    tile_num_cum = torch.zeros([M_grid], dtype=torch.int32, device=device)
+    total_tiles = torch.zeros([1], dtype=torch.int32, device=device)
+    E_PAD = max(1 << (epr - 1).bit_length(), 1)  # power-of-two >= epr
+    num_sms = min(num_sms, torch.cuda.get_device_properties(device).multi_processor_count)
+    kernel_build_gemm_tiling[(num_sms, )](
+        split_size,
+        split_size_cum,
+        expert_ids,
+        tile_num,
+        tile_num_cum,
+        total_tiles,
+        epr,
+        E_PAD,
+        block_m,
+        num_sms,
+    )
+    return dict(
+        block_m=block_m,
+        expert_ids=expert_ids,
+        split_size_cum=split_size_cum,
+        tile_num=tile_num,
+        tile_num_cum=tile_num_cum,
+        total_tiles=total_tiles,
+    )
+
+
+def _build_dispatch_metadata_device(ctx: "EpA2AFusedContext", topk_indices: torch.Tensor, block_m: int,
+                                    num_sms: int = 64):
+    """Device-kernel version of ``_build_dispatch_metadata`` (same meta keys).
+
+    Replaces the host ``bincount`` + ``all_gather_into_tensor`` + recv-offset / tiling torch
+    ops with on-device kernels: only one device->host sync remains (reading ``M_local``).
+    """
+    device = topk_indices.device
+    ws = ctx.world_size
+    epr = ctx.experts_per_rank
+    num_experts = ctx.num_tot_experts
+
+    # Validate at this public-boundary entry (preprocess feeds user routing here): fail early and
+    # clearly, consistently with the host path. Without it the device bincount would silently *skip*
+    # out-of-range ids (the lower-bound guard), yielding a descriptor based on filtered routing.
+    assert bool(((topk_indices >= 0) & (topk_indices < num_experts)).all()), \
+        "topk_indices out of range [0, num_tot_experts); drop-token / invalid ids are not supported"
+
+    # local_splits[e] via device bincount into the symmetric all-gather source buffer
+    ctx.local_splits_buf.zero_()
+    bincount(topk_indices.reshape(-1).contiguous(), num_experts, output=ctx.local_splits_buf)
+
+    recv_buf_offset = torch.zeros((ws, epr, ws), dtype=torch.int32, device=device)
+    num_input_tokens_per_rank = torch.zeros((ws, ), dtype=torch.int32, device=device)
+    num_recv_tokens_per_rank = torch.zeros((ws, ), dtype=torch.int32, device=device)
+    split_size = torch.zeros((epr, ), dtype=torch.int32, device=device)  # zeroed: atomic_add target
+
+    # Stays on-stream: cross-rank sync is done entirely inside the kernel (grid barrier ->
+    # barrier_all_block -> grid barrier), so NO host ep_barrier is needed here -- matching the
+    # validated `get_ag_splits_and_recv_offset_for_dispatch_intra_node` (ep_a2a_intra_node.py),
+    # which uses zero host barriers. ``barrier_all_block`` provides remote-op quiescence, so a
+    # stale ``splits_signal_buf`` (SET=1 from a prior call) is harmless and needs no reset; it is
+    # zeroed once at allocation. Only the grid-barrier counter must be reset per launch.
+    ctx.meta_grid_sync.zero_()
+
+    BLOCK_SIZE = max(1 << (num_experts - 1).bit_length(), 1)  # power-of-two >= num_experts
+    kernel_build_fused_dispatch_metadata[(ws, )](
+        ctx.local_splits_buf,
+        ctx.full_splits_buf,
+        ctx.splits_signal_buf,
+        recv_buf_offset,
+        num_input_tokens_per_rank,
+        num_recv_tokens_per_rank,
+        split_size,
+        ctx.meta_grid_sync,
+        epr,
+        ctx.topk,
+        BLOCK_SIZE,
+        num_warps=8,
+    )
+
+    M_local = int(num_recv_tokens_per_rank[ctx.rank].item())
+    meta = dict(
+        # clone: ctx.local_splits_buf is shared/overwritten by the next preprocess, so a
+        # descriptor must own a stable copy (dispatch reads local_splits for signal decisions).
+        local_splits=ctx.local_splits_buf.clone(),
+        recv_buf_offset=recv_buf_offset,
+        num_input_tokens_per_rank=num_input_tokens_per_rank,
+        num_recv_tokens_per_rank=num_recv_tokens_per_rank,
+        M_local=M_local,
+        split_size=split_size,
+        metadata_backend="device",
+    )
+    meta.update(_build_gemm_tiling_device(split_size, block_m, epr, device, M_local, num_sms=num_sms))
     return meta
 
 
@@ -568,6 +843,7 @@ def fused_dispatch_token_moe_grouped_gemm(
     gemm_weight: torch.Tensor,  # [experts_per_rank, hidden, N]
     *,  # keyword-only below: avoids any silent positional misbind of the new `meta` arg
     meta: Optional[dict] = None,  # precomputed layout metadata (e.g. from a layer.preprocess); built if None
+    use_device_metadata: bool = True,  # build meta with device kernels (host torch fallback if False)
     num_sms: int = 64,
     num_dispatch_tasks: int = 20,
     BLOCK_SIZE_M: int = 128,
@@ -582,6 +858,12 @@ def fused_dispatch_token_moe_grouped_gemm(
 
     ``meta`` carries the layout (recv offsets, scatter idx, per-rank token
     counts) needed by a subsequent combine.
+
+    Contract: ``topk_indices`` must be in ``[0, num_tot_experts)`` on **every** rank
+    (drop-token / negative sentinels are unsupported). The range check is per-rank
+    local, so passing invalid routing on only *some* ranks is undefined behavior and
+    may hang at the next cross-rank step rather than failing cleanly — callers must
+    guarantee valid routing on all ranks.
     """
     assert input.is_contiguous() and input.dtype == ctx.dtype
     assert topk_indices.dtype == torch.int32 and topk_indices.shape[1] == ctx.topk and topk_indices.is_contiguous()
@@ -590,12 +872,18 @@ def fused_dispatch_token_moe_grouped_gemm(
     assert hidden == ctx.hidden and num_tokens <= ctx.max_tokens
     G, K, N = gemm_weight.shape
     assert G == ctx.experts_per_rank and K == ctx.hidden
-    # Every (token, slot) must map to a real expert in [0, num_tot_experts).
+    # Validate the routing the dispatch kernel will actually scatter on. This is the safety boundary
+    # for the scatter pointer arithmetic, so it always runs on the *current* topk_indices: a precomputed
+    # meta only proves some indices were validated at build time, not that these are them / unmutated.
+    # Per-rank local: callers must pass in-range routing on every rank (see docstring).
     assert bool(((topk_indices >= 0) & (topk_indices < ctx.num_tot_experts)).all()), \
         "topk_indices out of range [0, num_tot_experts)"
 
     if meta is None:
-        meta = _build_dispatch_metadata(ctx, topk_indices, BLOCK_SIZE_M)
+        if use_device_metadata:
+            meta = _build_dispatch_metadata_device(ctx, topk_indices, BLOCK_SIZE_M, num_sms=num_sms)
+        else:
+            meta = _build_dispatch_metadata(ctx, topk_indices, BLOCK_SIZE_M)
     else:
         assert meta.get("block_m") == BLOCK_SIZE_M, \
             "precomputed meta was built with a different BLOCK_SIZE_M than this launch"
@@ -855,6 +1143,7 @@ def fused_group_gemm_combine_token(
     meta: dict,  # layout descriptor returned by fused_dispatch_token_moe_grouped_gemm
     topk_indices: torch.Tensor,  # [num_tokens, topk] int32 (same as dispatch)
     topk_weights: Optional[torch.Tensor] = None,  # [num_tokens, topk] fp32 routing weights
+    use_device_metadata: Optional[bool] = None,  # None -> follow meta["metadata_backend"]; else override
     num_sms: int = 64,
     BLOCK_SIZE_M: int = 128,
     BLOCK_SIZE_N: int = 128,
@@ -889,7 +1178,15 @@ def fused_group_gemm_combine_token(
         topk_weights = torch.empty((1, ), dtype=torch.float32, device=device)
 
     token_dst_scatter_idx = meta["token_dst_scatter_idx"]
-    tiling = _build_gemm_tiling(meta["split_size"], BLOCK_SIZE_M, device)
+    # When unset, follow how the dispatch metadata was built so combine stays consistent
+    # with dispatch (avoids silently running device tiling after a host-metadata dispatch).
+    if use_device_metadata is None:
+        use_device_metadata = meta.get("metadata_backend", "device") == "device"
+    if use_device_metadata:
+        tiling = _build_gemm_tiling_device(meta["split_size"], BLOCK_SIZE_M, ctx.experts_per_rank, device,
+                                           meta["M_local"], num_sms=num_sms)
+    else:
+        tiling = _build_gemm_tiling(meta["split_size"], BLOCK_SIZE_M, device)
 
     if combine_output is None:
         combine_output = torch.empty([num_tokens, N2], dtype=ctx.dtype, device=device)

--- a/python/triton_dist/layers/amd/ep_a2a_fused_layer.py
+++ b/python/triton_dist/layers/amd/ep_a2a_fused_layer.py
@@ -1,0 +1,237 @@
+################################################################################
+#
+# Copyright (c) 2025 ByteDance Ltd. and/or its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+################################################################################
+"""
+AMD (HIP/ROCm) fused EP All-to-All + grouped GEMM MoE layer.
+
+``EpAll2AllFusedOp`` exposes the fused MoE as an ``nn.Module`` with a
+``preprocess`` -> ``mega_dispatch_group_gemm`` -> ``mega_group_gemm_combine`` flow
+(plus ``dispatch_postprocess`` / ``combine_preprocess`` / ``ep_barrier_all`` /
+``sync`` / ``finalize`` and an ``EPAllToAllLayoutDesc`` descriptor), built on the
+AMD mega kernels in ``kernels/amd/ep_all2all_fused.py``.
+
+  * combine uses serial / gather mode;
+  * symmetric buffers are allocated eagerly via ``EpA2AFusedContext`` with a fixed
+    ``capacity`` (the host raises ``RuntimeError`` if a rank would exceed it);
+  * weights are this rank's local expert slices
+    (``w1 = [experts_per_rank, hidden, inter]``, ``w2 = [experts_per_rank, inter, hidden]``);
+    combine maps expert outputs back to ``hidden``.
+"""
+
+import dataclasses
+from typing import Callable, Optional
+
+import torch
+import torch.distributed
+
+from triton_dist.kernels.amd.ep_all2all_fused import (
+    create_ep_a2a_fused_context,
+    fused_dispatch_token_moe_grouped_gemm,
+    fused_group_gemm_combine_token,
+    _build_dispatch_metadata,
+)
+
+
+@dataclasses.dataclass
+class EPAllToAllLayoutDesc:
+    """AMD layout descriptor produced by ``EpAll2AllFusedOp.preprocess`` and
+    consumed by ``mega_dispatch_group_gemm`` / ``mega_group_gemm_combine``.
+
+    The dispatch/combine path only reads ``meta`` and ``topk_indices_tensor`` (plus
+    ``token_dst_scatter_idx`` via ``meta`` after dispatch). The per-expert / per-rank
+    count tensors below are populated for descriptor parity only -- see their notes.
+    """
+    num_dispatch_token_cur_rank: int  # this rank's input-token count (T)
+    recv_buf_offset_per_expert: torch.Tensor  # int32 [ws, epr, ws]. Not in use; reserved for future path
+    recv_buf_tokens_per_expert: torch.Tensor  # int32 [epr]. Not in use; reserved for future path
+    num_recv_tokens_per_rank: torch.Tensor  # int32 [ws]. Not in use; reserved for future path
+    num_input_tokens_per_rank: torch.Tensor  # int32 [ws]. Not in use; reserved for future path
+    topk_indices_tensor: torch.Tensor  # int32 [num_tokens, topk]
+    num_recv_tokens_cur_rank: int  # this rank's received-token count (M_local)
+    meta: dict  # internal metadata dict consumed by the AMD kernels
+    token_dst_scatter_idx: Optional[torch.Tensor] = None  # int32 [num_tokens, topk]; filled by dispatch
+
+
+class EpAll2AllFusedOp(torch.nn.Module):
+    """Fused EP All-to-All + grouped GEMM MoE op for AMD GPUs."""
+
+    def __init__(
+        self,
+        ep_group: torch.distributed.ProcessGroup,
+        max_tokens: int,
+        hidden: int,
+        topk: int,
+        num_tot_experts: int,
+        local_world_size: Optional[int] = None,
+        dtype: torch.dtype = torch.bfloat16,
+        weight_dtype: torch.dtype = torch.float32,  # Not in use; reserved for future path
+        num_sm: int = 64,
+        capacity: Optional[float] = None,
+        FWD_GEMM_BLOCK_SIZE_N: int = 128,
+        COMBINE_GEMM_BLOCK_SIZE_N: int = 128,
+        GROUP_GEMM_BLOCK_SIZE_M: int = 128,
+        gemm_BLOCK_SIZE_K: int = 64,
+        gemm_GROUP_SIZE_M: int = 4,
+        num_warps: int = 8,
+        num_stages: int = 2,
+        num_dispatch_tasks: int = 16,
+    ):
+        super().__init__()
+        self.ep_group = ep_group
+        self.rank = ep_group.rank()
+        self.world_size = ep_group.size()
+        self.local_world_size = self.world_size if local_world_size is None else local_world_size
+        assert self.world_size == self.local_world_size, "EpAll2AllFusedOp requires world_size == local_world_size"
+        assert num_tot_experts % self.world_size == 0, "num_tot_experts must be divisible by world_size"
+
+        self.max_tokens = max_tokens
+        self.hidden = hidden
+        self.topk = topk
+        self.num_tot_experts = num_tot_experts
+        self.experts_per_rank = num_tot_experts // self.world_size
+        self.dtype = dtype
+        self.weight_dtype = weight_dtype  # Not in use; reserved for future path
+        # `capacity` defaults to world_size (covers the worst-case all-to-one receive).
+        self.capacity = float(self.world_size) if capacity is None else float(capacity)
+
+        # tuning knobs (forwarded to the mega kernels)
+        self.num_sm = num_sm
+        self.num_dispatch_tasks = num_dispatch_tasks
+        self.FWD_GEMM_BLOCK_SIZE_N = FWD_GEMM_BLOCK_SIZE_N
+        self.COMBINE_GEMM_BLOCK_SIZE_N = COMBINE_GEMM_BLOCK_SIZE_N
+        self.GROUP_GEMM_BLOCK_SIZE_M = GROUP_GEMM_BLOCK_SIZE_M
+        self.gemm_BLOCK_SIZE_K = gemm_BLOCK_SIZE_K
+        self.gemm_GROUP_SIZE_M = gemm_GROUP_SIZE_M
+        self.num_warps = num_warps
+        self.num_stages = num_stages
+
+        # eager symmetric-buffer allocation.
+        self.ctx = create_ep_a2a_fused_context(
+            ep_group, max_tokens=max_tokens, hidden=hidden, topk=topk, num_tot_experts=num_tot_experts,
+            rank=self.rank, world_size=self.world_size, dtype=dtype, weight_dtype=weight_dtype,
+            capacity=self.capacity)
+
+    # ===================== buffer-management API (parity) =====================
+    def sync(self):
+        """Not in use; reserved for future path (symmetric buffers are allocated eagerly in ``__init__``)."""
+
+    def materialize(self):
+        """Not in use; reserved for future path."""
+        self.sync()
+
+    def finalize(self):
+        self.ctx.finalize()
+
+    def ep_barrier_all(self):
+        self.ctx.ep_barrier()
+
+    # ============================= preprocess =================================
+    def preprocess(self, exp_indices: torch.Tensor) -> EPAllToAllLayoutDesc:
+        """Cross-rank split exchange + recv-offset + grouped-GEMM tiling (computed host-side in torch)."""
+        assert exp_indices.dtype == torch.int32 and exp_indices.shape[1] == self.topk and exp_indices.is_contiguous()
+        meta = _build_dispatch_metadata(self.ctx, exp_indices, self.GROUP_GEMM_BLOCK_SIZE_M)
+        return EPAllToAllLayoutDesc(
+            num_dispatch_token_cur_rank=exp_indices.shape[0],
+            recv_buf_offset_per_expert=meta["recv_buf_offset"],
+            recv_buf_tokens_per_expert=meta["split_size"],
+            num_recv_tokens_per_rank=meta["num_recv_tokens_per_rank"],
+            num_input_tokens_per_rank=meta["num_input_tokens_per_rank"],
+            topk_indices_tensor=exp_indices,
+            num_recv_tokens_cur_rank=meta["M_local"],
+            meta=meta,
+        )
+
+    def dispatch_postprocess(self):
+        """Not in use; reserved for future path (the forward path resets these counters/barriers in-kernel)."""
+        self.ctx.task_counter.zero_()
+        self.ctx.expert_counter.zero_()
+        self.ctx.barriers_buf.zero_()
+
+    def combine_preprocess(self, M_recv: Optional[int] = None):  # M_recv: Not in use; reserved for future path
+        """Not in use; reserved for future path (the forward path resets the grid-sync counter in-kernel)."""
+        self.ctx.combine_grid_sync.zero_()
+
+    # ===================== dispatch + grouped GEMM (gemm1) ====================
+    def mega_dispatch_group_gemm(
+        self,
+        input: torch.Tensor,  # [num_tokens, hidden]
+        exp_indices: torch.Tensor,  # [num_tokens, topk] int32 (must be the tensor passed to preprocess)
+        ep_a2a_layout_desc: EPAllToAllLayoutDesc,
+        gemm_weight: torch.Tensor,  # [experts_per_rank, hidden, inter]
+        gemm_output_data: Optional[torch.Tensor] = None,
+        gemm_BLOCK_SIZE_N: Optional[int] = None,
+    ):
+        """Fused dispatch + grouped GEMM-1. Returns ``(gemm1_out[M, inter], desc)``."""
+        # `meta` was built from the desc's indices; bind to that single source of truth.
+        assert exp_indices is ep_a2a_layout_desc.topk_indices_tensor, \
+            "exp_indices must be the tensor passed to preprocess (use ep_a2a_layout_desc.topk_indices_tensor)"
+        gemm1_out, meta = fused_dispatch_token_moe_grouped_gemm(
+            self.ctx, input, ep_a2a_layout_desc.topk_indices_tensor, gemm_weight, meta=ep_a2a_layout_desc.meta,
+            num_sms=self.num_sm, num_dispatch_tasks=self.num_dispatch_tasks, BLOCK_SIZE_M=self.GROUP_GEMM_BLOCK_SIZE_M,
+            BLOCK_SIZE_N=(gemm_BLOCK_SIZE_N or self.FWD_GEMM_BLOCK_SIZE_N), BLOCK_SIZE_K=self.gemm_BLOCK_SIZE_K,
+            GROUP_SIZE_M=self.gemm_GROUP_SIZE_M, num_warps=self.num_warps, num_stages=self.num_stages,
+            gemm_output=gemm_output_data)
+        ep_a2a_layout_desc.token_dst_scatter_idx = meta.get("token_dst_scatter_idx")
+        return gemm1_out, ep_a2a_layout_desc
+
+    # ===================== grouped GEMM (gemm2) + combine =====================
+    def mega_group_gemm_combine(
+        self,
+        gemm_input_data: torch.Tensor,  # [M, inter] (e.g. act(gemm1 out))
+        gemm_weight: torch.Tensor,  # [experts_per_rank, inter, hidden]
+        ep_a2a_layout_desc: EPAllToAllLayoutDesc,
+        gate_input: Optional[torch.Tensor] = None,  # [num_tokens, topk] routing weights
+        combine_output: Optional[torch.Tensor] = None,
+        gemm_BLOCK_SIZE_N: Optional[int] = None,
+        combine_mode: str = "serial",
+    ) -> torch.Tensor:
+        """Fused grouped GEMM-2 + combine (serial/gather). Returns ``[num_tokens, hidden]``."""
+        assert combine_mode == "serial", "AMD combine only supports serial/gather mode"
+        return fused_group_gemm_combine_token(
+            self.ctx, gemm_input_data, gemm_weight, ep_a2a_layout_desc.meta,
+            ep_a2a_layout_desc.topk_indices_tensor, topk_weights=gate_input, num_sms=self.num_sm,
+            BLOCK_SIZE_M=self.GROUP_GEMM_BLOCK_SIZE_M,
+            BLOCK_SIZE_N=(gemm_BLOCK_SIZE_N or self.COMBINE_GEMM_BLOCK_SIZE_N), BLOCK_SIZE_K=self.gemm_BLOCK_SIZE_K,
+            GROUP_SIZE_M=self.gemm_GROUP_SIZE_M, num_warps=self.num_warps, num_stages=self.num_stages,
+            combine_output=combine_output)
+
+    # ============================ full forward ================================
+    def forward(
+        self,
+        hidden_states: torch.Tensor,  # [num_tokens, hidden]
+        topk_indices: torch.Tensor,  # [num_tokens, topk] int32, global expert ids
+        w1: torch.Tensor,  # [experts_per_rank, hidden, inter]
+        w2: torch.Tensor,  # [experts_per_rank, inter, hidden]
+        topk_weights: Optional[torch.Tensor] = None,  # [num_tokens, topk]
+        activation: Callable[[torch.Tensor], torch.Tensor] = torch.relu,
+    ) -> torch.Tensor:
+        """Convenience full MoE forward: preprocess -> dispatch+gemm1 -> act -> gemm2+combine."""
+        desc = self.preprocess(topk_indices)
+        gemm1_out, desc = self.mega_dispatch_group_gemm(hidden_states, topk_indices, desc, w1)
+        act = activation(gemm1_out).contiguous()
+        return self.mega_group_gemm_combine(act, w2, desc, gate_input=topk_weights)
+
+
+# AMD-naming alias (consistent with EPAll2AllLayer / EPLowLatencyAllToAllLayer).
+EPAll2AllFusedLayer = EpAll2AllFusedOp

--- a/python/triton_dist/layers/amd/ep_a2a_fused_layer.py
+++ b/python/triton_dist/layers/amd/ep_a2a_fused_layer.py
@@ -50,6 +50,7 @@ from triton_dist.kernels.amd.ep_all2all_fused import (
     fused_dispatch_token_moe_grouped_gemm,
     fused_group_gemm_combine_token,
     _build_dispatch_metadata,
+    _build_dispatch_metadata_device,
 )
 
 
@@ -96,6 +97,7 @@ class EpAll2AllFusedOp(torch.nn.Module):
         num_warps: int = 8,
         num_stages: int = 2,
         num_dispatch_tasks: int = 16,
+        use_device_metadata: bool = True,
     ):
         super().__init__()
         self.ep_group = ep_group
@@ -125,6 +127,8 @@ class EpAll2AllFusedOp(torch.nn.Module):
         self.gemm_GROUP_SIZE_M = gemm_GROUP_SIZE_M
         self.num_warps = num_warps
         self.num_stages = num_stages
+        # build dispatch/combine metadata with device kernels (host torch fallback if False)
+        self.use_device_metadata = use_device_metadata
 
         # eager symmetric-buffer allocation.
         self.ctx = create_ep_a2a_fused_context(
@@ -148,9 +152,18 @@ class EpAll2AllFusedOp(torch.nn.Module):
 
     # ============================= preprocess =================================
     def preprocess(self, exp_indices: torch.Tensor) -> EPAllToAllLayoutDesc:
-        """Cross-rank split exchange + recv-offset + grouped-GEMM tiling (computed host-side in torch)."""
+        """Cross-rank split exchange + recv-offset + grouped-GEMM tiling.
+
+        Built on-device by default (``use_device_metadata=True``); set it False to use the host torch path.
+        ``exp_indices`` must be in ``[0, num_tot_experts)`` on every rank — the range check is per-rank
+        local, so invalid routing on only some ranks may hang rather than fail cleanly.
+        """
         assert exp_indices.dtype == torch.int32 and exp_indices.shape[1] == self.topk and exp_indices.is_contiguous()
-        meta = _build_dispatch_metadata(self.ctx, exp_indices, self.GROUP_GEMM_BLOCK_SIZE_M)
+        if self.use_device_metadata:
+            meta = _build_dispatch_metadata_device(self.ctx, exp_indices, self.GROUP_GEMM_BLOCK_SIZE_M,
+                                                   num_sms=self.num_sm)
+        else:
+            meta = _build_dispatch_metadata(self.ctx, exp_indices, self.GROUP_GEMM_BLOCK_SIZE_M)
         return EPAllToAllLayoutDesc(
             num_dispatch_token_cur_rank=exp_indices.shape[0],
             recv_buf_offset_per_expert=meta["recv_buf_offset"],
@@ -188,7 +201,8 @@ class EpAll2AllFusedOp(torch.nn.Module):
             "exp_indices must be the tensor passed to preprocess (use ep_a2a_layout_desc.topk_indices_tensor)"
         gemm1_out, meta = fused_dispatch_token_moe_grouped_gemm(
             self.ctx, input, ep_a2a_layout_desc.topk_indices_tensor, gemm_weight, meta=ep_a2a_layout_desc.meta,
-            num_sms=self.num_sm, num_dispatch_tasks=self.num_dispatch_tasks, BLOCK_SIZE_M=self.GROUP_GEMM_BLOCK_SIZE_M,
+            use_device_metadata=self.use_device_metadata, num_sms=self.num_sm,
+            num_dispatch_tasks=self.num_dispatch_tasks, BLOCK_SIZE_M=self.GROUP_GEMM_BLOCK_SIZE_M,
             BLOCK_SIZE_N=(gemm_BLOCK_SIZE_N or self.FWD_GEMM_BLOCK_SIZE_N), BLOCK_SIZE_K=self.gemm_BLOCK_SIZE_K,
             GROUP_SIZE_M=self.gemm_GROUP_SIZE_M, num_warps=self.num_warps, num_stages=self.num_stages,
             gemm_output=gemm_output_data)
@@ -210,7 +224,8 @@ class EpAll2AllFusedOp(torch.nn.Module):
         assert combine_mode == "serial", "AMD combine only supports serial/gather mode"
         return fused_group_gemm_combine_token(
             self.ctx, gemm_input_data, gemm_weight, ep_a2a_layout_desc.meta,
-            ep_a2a_layout_desc.topk_indices_tensor, topk_weights=gate_input, num_sms=self.num_sm,
+            ep_a2a_layout_desc.topk_indices_tensor, topk_weights=gate_input,
+            use_device_metadata=self.use_device_metadata, num_sms=self.num_sm,
             BLOCK_SIZE_M=self.GROUP_GEMM_BLOCK_SIZE_M,
             BLOCK_SIZE_N=(gemm_BLOCK_SIZE_N or self.COMBINE_GEMM_BLOCK_SIZE_N), BLOCK_SIZE_K=self.gemm_BLOCK_SIZE_K,
             GROUP_SIZE_M=self.gemm_GROUP_SIZE_M, num_warps=self.num_warps, num_stages=self.num_stages,

--- a/python/triton_dist/test/amd/test_ep_a2a_fused.py
+++ b/python/triton_dist/test/amd/test_ep_a2a_fused.py
@@ -1,0 +1,223 @@
+################################################################################
+#
+# Copyright (c) 2025 ByteDance Ltd. and/or its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, ...
+#
+################################################################################
+"""
+Correctness test for the AMD fused EP-A2A + grouped-GEMM "mega kernel" forward.
+
+Exercises the full fused MoE forward:
+    dispatch + gemm1 (mega)  ->  relu  ->  gemm2 + combine (mega)
+and compares against a single-process PyTorch reference (every rank holds an
+identical full expert-weight table; the fused path only uses this rank's slice).
+
+Checks run BY DEFAULT (pass --no-check to only init/finalize). Cases (each builds
+its own context; all ranks run the same sequence so collectives stay matched):
+  - baseline    : random distinct top-k routing
+  - topk1       : top-1 routing
+  - skew_rank0  : every token -> rank-0's experts; other ranks receive 0 tokens
+                  (exercises the M_local == 0 path that must NOT early-return)
+  - ktail       : M / H / I not multiples of the tile sizes, incl. K not a
+                  multiple of BLOCK_SIZE_K (reduction-dim tail masking)
+  - more_experts: experts_per_rank = 4 and topk = 4 (wider local-expert indexing)
+  - fp16        : float16 dtype
+  - ungated     : combine without routing weights (topk_weights=None)
+  - partial     : num_tokens < max_tokens (+ per-iter varying counts -> ctx reuse)
+  - capacity    : capacity too small -> every rank must raise a clear RuntimeError
+
+Usage (mori_shmem; RCCL on this firmware requires HSA_NO_SCRATCH_RECLAIM=1):
+    HIP_VISIBLE_DEVICES=4,5,6,7 ARNOLD_WORKER_GPU=4 \\
+    TRITON_DIST_SHMEM_BACKEND=mori_shmem HSA_NO_SCRATCH_RECLAIM=1 \\
+    bash ./scripts/launch_amd.sh ./python/triton_dist/test/amd/test_ep_a2a_fused.py
+"""
+
+import os
+import sys
+import argparse
+import random
+
+os.environ.setdefault("TRITON_DIST_SHMEM_BACKEND", "mori_shmem")
+os.environ.setdefault("MORI_SHMEM_HEAP_SIZE", "4G")
+
+_test_dir = os.path.dirname(os.path.abspath(__file__))
+_workspace_root = os.path.abspath(os.path.join(_test_dir, "../../../.."))
+_triton_dist_python_path = os.path.join(_workspace_root, "python")
+if _triton_dist_python_path not in sys.path:
+    sys.path.insert(0, _triton_dist_python_path)
+_current_pythonpath = os.environ.get("PYTHONPATH", "")
+if _triton_dist_python_path not in _current_pythonpath:
+    os.environ["PYTHONPATH"] = (f"{_triton_dist_python_path}:{_current_pythonpath}"
+                                if _current_pythonpath else _triton_dist_python_path)
+_triton_python_path = os.path.join(_workspace_root, "3rdparty/triton/python")
+if os.path.exists(_triton_python_path):
+    sys.path.insert(0, _triton_python_path)
+
+import torch
+import torch.distributed
+
+from triton_dist.utils import initialize_distributed, finalize_distributed
+from triton_dist.kernels.amd.ep_all2all_fused import (
+    create_ep_a2a_fused_context,
+    fused_dispatch_token_moe_grouped_gemm,
+    fused_group_gemm_combine_token,
+)
+
+DTYPE_MAP = {"bfloat16": torch.bfloat16, "float16": torch.float16}
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="AMD fused EP-A2A + grouped GEMM test")
+    p.add_argument("--iters", type=int, default=2, help="check rounds per case")
+    p.add_argument("--dtype", default="bfloat16", choices=list(DTYPE_MAP.keys()), help="default dtype")
+    p.add_argument("--num_sms", type=int, default=64)
+    p.add_argument("--num_dispatch_tasks", type=int, default=16)
+    p.add_argument("--atol", type=float, default=2e-2)
+    p.add_argument("--rtol", type=float, default=2e-2)
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--check", action="store_true", help="(deprecated; checks run by default)")
+    p.add_argument("--no-check", dest="no_check", action="store_true", help="skip checks (init/finalize only)")
+    return p.parse_args()
+
+
+# ---------------------------------------------------------------------------
+#  Routing generators (all produce [n, topk] int32, distinct experts per token)
+# ---------------------------------------------------------------------------
+def gen_indices(routing, n, G, topk, epr):
+    if routing == "random":
+        exp_list = list(range(G))
+        rows = [random.sample(exp_list, topk) for _ in range(n)]
+    elif routing == "skew_rank0":
+        assert topk <= epr  # every token -> rank-0's experts [0, epr)
+        rows = [list(range(topk)) for _ in range(n)]
+    elif routing == "balanced_rr":
+        rows = [[(t * topk + j) % G for j in range(topk)] for t in range(n)]
+    else:
+        raise ValueError(routing)
+    return torch.tensor(rows, dtype=torch.int32)
+
+
+def ref_moe(x, idx, weights, W1, W2):
+    """out[t] = sum_j w[t,j] * relu(x[t] @ W1[e]) @ W2[e]  (model-dtype matmul, fp32 reduce)."""
+    T, k = idx.shape
+    H = x.shape[1]
+    flat_e = idx.reshape(-1).long()
+    xe = x.repeat_interleave(k, dim=0)
+    h = torch.relu(torch.bmm(xe.unsqueeze(1), W1[flat_e]).squeeze(1))
+    y = torch.bmm(h.unsqueeze(1), W2[flat_e]).squeeze(1)
+    y = y.float() * weights.reshape(-1, 1).float()
+    return y.reshape(T, k, H).sum(dim=1).to(x.dtype)
+
+
+def run_case(args, EP_GROUP, rank, world_size, device, *, name, M, H, I, G, topk, capacity, routing, case_seed,
+             dtype="bfloat16", n_tokens=None, gated=True, expect_capacity_error=False):
+    dt = DTYPE_MAP[dtype]
+    epr = G // world_size
+    assert G % world_size == 0 and topk <= G
+
+    wgen = torch.Generator(device="cuda").manual_seed(args.seed + 7919 * case_seed)
+    W1 = (torch.randn(G, H, I, generator=wgen, device=device, dtype=torch.float32) * (1.0 / H)**0.5).to(dt)
+    W2 = (torch.randn(G, I, H, generator=wgen, device=device, dtype=torch.float32) * (1.0 / I)**0.5).to(dt)
+    W1_local = W1[rank * epr:(rank + 1) * epr].contiguous()
+    W2_local = W2[rank * epr:(rank + 1) * epr].contiguous()
+
+    ctx = create_ep_a2a_fused_context(EP_GROUP, max_tokens=M, hidden=H, topk=topk, num_tot_experts=G, rank=rank,
+                                      world_size=world_size, dtype=dt, weight_dtype=torch.float32, capacity=capacity)
+    max_abs = max_rel = 0.0
+    try:
+        for it in range(args.iters):
+            torch.manual_seed(args.seed + 1000 * it + rank + 131 * case_seed)
+            random.seed(args.seed + 1000 * it + rank + 131 * case_seed)
+            # vary token count per iter (<= max_tokens) to exercise context reuse
+            n = M if n_tokens is None else min(n_tokens + 16 * it, M)
+            x = (torch.randn(n, H, device=device, dtype=torch.float32) * 0.5).to(dt)
+            idx = gen_indices(routing, n, G, topk, epr).to(device)
+            weights = torch.rand(n, topk, device=device, dtype=torch.float32) + 0.5
+
+            if expect_capacity_error:
+                raised = False
+                try:
+                    fused_dispatch_token_moe_grouped_gemm(ctx, x, idx, W1_local, num_sms=args.num_sms,
+                                                          num_dispatch_tasks=args.num_dispatch_tasks)
+                except RuntimeError as e:
+                    raised = "cap_tokens" in str(e)
+                assert raised, f"[{name}] expected a capacity RuntimeError but none was raised"
+                continue
+
+            ref_w = weights if gated else torch.ones_like(weights)
+            ref = ref_moe(x, idx, ref_w, W1, W2)
+            gemm1_out, meta = fused_dispatch_token_moe_grouped_gemm(ctx, x, idx, W1_local, num_sms=args.num_sms,
+                                                                    num_dispatch_tasks=args.num_dispatch_tasks)
+            act = torch.relu(gemm1_out).contiguous()
+            out = fused_group_gemm_combine_token(ctx, act, W2_local, meta, idx,
+                                                 topk_weights=(weights if gated else None), num_sms=args.num_sms)
+            torch.cuda.synchronize()
+            assert out.shape == ref.shape, f"[{name}] shape {out.shape} vs {ref.shape}"
+            torch.testing.assert_close(out.float(), ref.float(), atol=args.atol, rtol=args.rtol)
+            d = (out.float() - ref.float()).abs()
+            max_abs = max(max_abs, float(d.max()))
+            max_rel = max(max_rel, float((d / (ref.float().abs() + 1e-6)).max()))
+    finally:
+        ctx.finalize()
+    torch.distributed.barrier(EP_GROUP)
+    if rank == 0:
+        extra = "" if expect_capacity_error else f" max_abs={max_abs:.3e} max_rel={max_rel:.3e}"
+        print(f"  [{name}] passed ({args.iters} iters){extra}", flush=True)
+
+
+def main():
+    args = parse_args()
+    EP_GROUP = initialize_distributed()
+    rank = EP_GROUP.rank()
+    world_size = EP_GROUP.size()
+    device = torch.cuda.current_device()
+    ws = world_size
+
+    cases = [
+        dict(name="baseline", M=256, H=512, I=1024, G=2 * ws, topk=2, capacity=float(ws), routing="random"),
+        dict(name="topk1", M=256, H=512, I=1024, G=2 * ws, topk=1, capacity=float(ws), routing="random"),
+        dict(name="skew_rank0", M=128, H=512, I=512, G=2 * ws, topk=2, capacity=float(ws), routing="skew_rank0"),
+        # K-tail: H and I are NOT multiples of BLOCK_SIZE_K(=64); M not a multiple of BLOCK_M
+        dict(name="ktail", M=200, H=328, I=520, G=2 * ws, topk=2, capacity=float(ws), routing="random"),
+        # wider local-expert indexing: experts_per_rank = 4, topk = 4
+        dict(name="more_experts", M=128, H=512, I=512, G=4 * ws, topk=4, capacity=float(ws), routing="random"),
+        # high top-k: 8 experts per token (subset of G = 4*ws)
+        dict(name="topk8", M=128, H=512, I=512, G=4 * ws, topk=8, capacity=float(ws), routing="random"),
+        dict(name="fp16", M=256, H=512, I=512, G=2 * ws, topk=2, capacity=float(ws), routing="random",
+             dtype="float16"),
+        dict(name="ungated", M=192, H=512, I=512, G=2 * ws, topk=2, capacity=float(ws), routing="random", gated=False),
+        # num_tokens < max_tokens, and per-iter varying token counts (context reuse)
+        dict(name="partial", M=256, H=512, I=512, G=2 * ws, topk=2, capacity=float(ws), routing="random",
+             n_tokens=100),
+        dict(name="capacity_too_small", M=256, H=256, I=256, G=2 * ws, topk=2, capacity=0.5, routing="balanced_rr",
+             expect_capacity_error=True),
+    ]
+
+    if args.no_check:
+        if rank == 0:
+            print("--no-check: skipping correctness checks", flush=True)
+    else:
+        for i, c in enumerate(cases):
+            run_case(args, EP_GROUP, rank, world_size, device, case_seed=i, **c)
+        print(f"RANK[{rank}]: all checks passed.", flush=True)
+        torch.distributed.barrier(EP_GROUP)
+        if rank == 0:
+            print("✅ all close!", flush=True)
+
+    finalize_distributed()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/triton_dist/test/amd/test_ep_a2a_fused_kernel.py
+++ b/python/triton_dist/test/amd/test_ep_a2a_fused_kernel.py
@@ -77,6 +77,8 @@ from triton_dist.kernels.amd.ep_all2all_fused import (
     create_ep_a2a_fused_context,
     fused_dispatch_token_moe_grouped_gemm,
     fused_group_gemm_combine_token,
+    _build_dispatch_metadata,
+    _build_dispatch_metadata_device,
 )
 
 DTYPE_MAP = {"bfloat16": torch.bfloat16, "float16": torch.float16}
@@ -125,8 +127,161 @@ def ref_moe(x, idx, weights, W1, W2):
     return y.reshape(T, k, H).sum(dim=1).to(x.dtype)
 
 
+def run_metadata_parity(args, EP_GROUP, rank, world_size, device, *, name, M, H, I, G, topk, capacity, routing,
+                        case_seed, block_m=128):
+    """Assert the device-side metadata kernels produce a layout byte-identical to the host torch path."""
+    epr = G // world_size
+    ctx = create_ep_a2a_fused_context(EP_GROUP, max_tokens=M, hidden=H, topk=topk, num_tot_experts=G, rank=rank,
+                                      world_size=world_size, dtype=torch.bfloat16, weight_dtype=torch.float32,
+                                      capacity=capacity)
+    try:
+        torch.manual_seed(args.seed + 131 * case_seed)
+        random.seed(args.seed + 131 * case_seed)
+        idx = gen_indices(routing, M, G, topk, epr).to(device)
+        # device first, then host (both are collectives; all ranks run the same order)
+        dev = _build_dispatch_metadata_device(ctx, idx, block_m, num_sms=args.num_sms)
+        host = _build_dispatch_metadata(ctx, idx, block_m)
+
+        assert dev["M_local"] == host["M_local"], f"[{name}] M_local {dev['M_local']} vs {host['M_local']}"
+        for key in ("recv_buf_offset", "num_input_tokens_per_rank", "num_recv_tokens_per_rank", "split_size",
+                    "local_splits"):
+            assert torch.equal(dev[key].reshape(-1).cpu(), host[key].reshape(-1).cpu()), f"[{name}] mismatch: {key}"
+        t = int(host["total_tiles"].item())
+        assert int(dev["total_tiles"].item()) == t, f"[{name}] total_tiles mismatch"
+        for key in ("expert_ids", "split_size_cum", "tile_num", "tile_num_cum"):
+            assert torch.equal(dev[key][:t].cpu(), host[key][:t].cpu()), f"[{name}] tiling mismatch: {key}"
+    finally:
+        ctx.finalize()
+    torch.distributed.barrier(EP_GROUP)
+    if rank == 0:
+        print(f"  [parity:{name}] device==host metadata", flush=True)
+
+
+def run_local_splits_alias_regression(args, EP_GROUP, rank, world_size, device):
+    """Regression: a device-metadata desc must own a stable `local_splits` copy.
+
+    Building a second desc on the same ctx must NOT mutate the first desc's local_splits
+    (was a real bug when `meta['local_splits']` aliased the shared `ctx.local_splits_buf`).
+    Collective-safe: every rank runs the same sequence.
+    """
+    G, topk, M, H = 2 * world_size, 1, 64, 256
+    ctx = create_ep_a2a_fused_context(EP_GROUP, max_tokens=M, hidden=H, topk=topk, num_tot_experts=G, rank=rank,
+                                      world_size=world_size, dtype=torch.bfloat16, weight_dtype=torch.float32,
+                                      capacity=float(world_size))
+    try:
+        idxA = torch.zeros((M, topk), dtype=torch.int32, device=device)  # all -> expert 0
+        idxB = torch.ones((M, topk), dtype=torch.int32, device=device)  # all -> expert 1
+        metaA = _build_dispatch_metadata_device(ctx, idxA, 128, num_sms=args.num_sms)
+        snapA = metaA["local_splits"].clone()
+        _ = _build_dispatch_metadata_device(ctx, idxB, 128, num_sms=args.num_sms)
+        assert metaA["local_splits"].data_ptr() != ctx.local_splits_buf.data_ptr(), \
+            "local_splits must not alias ctx.local_splits_buf"
+        assert torch.equal(metaA["local_splits"], snapA), \
+            "metaA['local_splits'] was mutated by a later preprocess (aliasing regression)"
+    finally:
+        ctx.finalize()
+    torch.distributed.barrier(EP_GROUP)
+    if rank == 0:
+        print("  [regression:local_splits_alias] desc owns a stable copy", flush=True)
+
+
+def run_invalid_id_regression(args, EP_GROUP, rank, world_size, device):
+    """Regression: building metadata with an out-of-range expert id must fail early & clearly
+    (both backends), not silently produce a filtered descriptor. Local assertion -> all ranks
+    raise symmetrically (collective-safe)."""
+    G, topk, M, H = 2 * world_size, 1, 64, 256
+    ctx = create_ep_a2a_fused_context(EP_GROUP, max_tokens=M, hidden=H, topk=topk, num_tot_experts=G, rank=rank,
+                                      world_size=world_size, dtype=torch.bfloat16, weight_dtype=torch.float32,
+                                      capacity=float(world_size))
+    try:
+        bad = torch.zeros((M, topk), dtype=torch.int32, device=device)
+        bad[0, 0] = -1  # invalid / drop sentinel
+        for builder, tag in ((_build_dispatch_metadata_device, "device"), (_build_dispatch_metadata, "host")):
+            raised = False
+            try:
+                builder(ctx, bad, 128)
+            except (AssertionError, RuntimeError):
+                raised = True
+            assert raised, f"[invalid_id:{tag}] expected metadata build to reject out-of-range id"
+    finally:
+        ctx.finalize()
+    torch.distributed.barrier(EP_GROUP)
+    if rank == 0:
+        print("  [regression:invalid_id] preprocess rejects out-of-range ids (device+host)", flush=True)
+
+
+def run_combine_autofollow_regression(args, EP_GROUP, rank, world_size, device):
+    """Regression: combine with use_device_metadata=None must follow meta['metadata_backend']
+    (locks the auto-follow branch) and stay numerically correct for both backends."""
+    G, topk, M, H, I = 2 * world_size, 2, 128, 256, 256
+    epr = G // world_size
+    wgen = torch.Generator(device="cuda").manual_seed(args.seed + 4242)
+    W1 = (torch.randn(G, H, I, generator=wgen, device=device, dtype=torch.float32) * (1.0 / H)**0.5).to(torch.bfloat16)
+    W2 = (torch.randn(G, I, H, generator=wgen, device=device, dtype=torch.float32) * (1.0 / I)**0.5).to(torch.bfloat16)
+    W1_local = W1[rank * epr:(rank + 1) * epr].contiguous()
+    W2_local = W2[rank * epr:(rank + 1) * epr].contiguous()
+    ctx = create_ep_a2a_fused_context(EP_GROUP, max_tokens=M, hidden=H, topk=topk, num_tot_experts=G, rank=rank,
+                                      world_size=world_size, dtype=torch.bfloat16, weight_dtype=torch.float32,
+                                      capacity=float(world_size))
+    try:
+        for backend_is_device in (False, True):
+            torch.manual_seed(args.seed + 99)
+            random.seed(args.seed + 99)
+            x = (torch.randn(M, H, device=device, dtype=torch.float32) * 0.5).to(torch.bfloat16)
+            idx = gen_indices("random", M, G, topk, epr).to(device)
+            weights = torch.rand(M, topk, device=device, dtype=torch.float32) + 0.5
+            ref = ref_moe(x, idx, weights, W1, W2)
+            gemm1_out, meta = fused_dispatch_token_moe_grouped_gemm(ctx, x, idx, W1_local,
+                                                                    use_device_metadata=backend_is_device,
+                                                                    num_sms=args.num_sms)
+            assert meta["metadata_backend"] == ("device" if backend_is_device else "host")
+            act = torch.relu(gemm1_out).contiguous()
+            # use_device_metadata omitted -> None -> must follow meta["metadata_backend"]
+            out = fused_group_gemm_combine_token(ctx, act, W2_local, meta, idx, topk_weights=weights,
+                                                 num_sms=args.num_sms)
+            torch.cuda.synchronize()
+            torch.testing.assert_close(out.float(), ref.float(), atol=args.atol, rtol=args.rtol)
+    finally:
+        ctx.finalize()
+    torch.distributed.barrier(EP_GROUP)
+    if rank == 0:
+        print("  [regression:combine_autofollow] combine follows meta backend (host+device)", flush=True)
+
+
+def run_precomputed_meta_bad_idx_regression(args, EP_GROUP, rank, world_size, device):
+    """Regression: reusing a precomputed (validated) meta with a DIFFERENT, out-of-range
+    topk_indices must still be rejected. dispatch validates the *current* indices it scatters on,
+    never trusting the meta's backend tag as proof the indices are valid (closes a bypass where a
+    tagged meta would skip the range check). Local assert -> all ranks raise symmetrically before
+    any collective."""
+    G, topk, M, H, I = 2 * world_size, 1, 64, 256, 256
+    epr = G // world_size
+    wgen = torch.Generator(device="cuda").manual_seed(args.seed + 555)
+    W1 = (torch.randn(G, H, I, generator=wgen, device=device, dtype=torch.float32) * (1.0 / H)**0.5).to(torch.bfloat16)
+    W1_local = W1[rank * epr:(rank + 1) * epr].contiguous()
+    ctx = create_ep_a2a_fused_context(EP_GROUP, max_tokens=M, hidden=H, topk=topk, num_tot_experts=G, rank=rank,
+                                      world_size=world_size, dtype=torch.bfloat16, weight_dtype=torch.float32,
+                                      capacity=float(world_size))
+    try:
+        x = (torch.randn(M, H, device=device, dtype=torch.float32) * 0.5).to(torch.bfloat16)
+        good = torch.zeros((M, topk), dtype=torch.int32, device=device)
+        _, meta = fused_dispatch_token_moe_grouped_gemm(ctx, x, good, W1_local, num_sms=args.num_sms)
+        bad = torch.full((M, topk), G + 1, dtype=torch.int32, device=device)  # out of range
+        raised = False
+        try:
+            fused_dispatch_token_moe_grouped_gemm(ctx, x, bad, W1_local, meta=meta, num_sms=args.num_sms)
+        except (AssertionError, RuntimeError):
+            raised = True
+        assert raised, "dispatch must reject out-of-range topk_indices even when a precomputed meta is passed"
+    finally:
+        ctx.finalize()
+    torch.distributed.barrier(EP_GROUP)
+    if rank == 0:
+        print("  [regression:precomputed_meta_bad_idx] dispatch revalidates current indices", flush=True)
+
+
 def run_case(args, EP_GROUP, rank, world_size, device, *, name, M, H, I, G, topk, capacity, routing, case_seed,
-             dtype="bfloat16", n_tokens=None, gated=True, expect_capacity_error=False):
+             dtype="bfloat16", n_tokens=None, gated=True, expect_capacity_error=False, use_device_metadata=True):
     dt = DTYPE_MAP[dtype]
     epr = G // world_size
     assert G % world_size == 0 and topk <= G
@@ -153,7 +308,9 @@ def run_case(args, EP_GROUP, rank, world_size, device, *, name, M, H, I, G, topk
             if expect_capacity_error:
                 raised = False
                 try:
-                    fused_dispatch_token_moe_grouped_gemm(ctx, x, idx, W1_local, num_sms=args.num_sms,
+                    fused_dispatch_token_moe_grouped_gemm(ctx, x, idx, W1_local,
+                                                          use_device_metadata=use_device_metadata,
+                                                          num_sms=args.num_sms,
                                                           num_dispatch_tasks=args.num_dispatch_tasks)
                 except RuntimeError as e:
                     raised = "cap_tokens" in str(e)
@@ -162,11 +319,14 @@ def run_case(args, EP_GROUP, rank, world_size, device, *, name, M, H, I, G, topk
 
             ref_w = weights if gated else torch.ones_like(weights)
             ref = ref_moe(x, idx, ref_w, W1, W2)
-            gemm1_out, meta = fused_dispatch_token_moe_grouped_gemm(ctx, x, idx, W1_local, num_sms=args.num_sms,
+            gemm1_out, meta = fused_dispatch_token_moe_grouped_gemm(ctx, x, idx, W1_local,
+                                                                    use_device_metadata=use_device_metadata,
+                                                                    num_sms=args.num_sms,
                                                                     num_dispatch_tasks=args.num_dispatch_tasks)
             act = torch.relu(gemm1_out).contiguous()
             out = fused_group_gemm_combine_token(ctx, act, W2_local, meta, idx,
-                                                 topk_weights=(weights if gated else None), num_sms=args.num_sms)
+                                                 topk_weights=(weights if gated else None),
+                                                 use_device_metadata=use_device_metadata, num_sms=args.num_sms)
             torch.cuda.synchronize()
             assert out.shape == ref.shape, f"[{name}] shape {out.shape} vs {ref.shape}"
             torch.testing.assert_close(out.float(), ref.float(), atol=args.atol, rtol=args.rtol)
@@ -209,12 +369,33 @@ def main():
              expect_capacity_error=True),
     ]
 
+    # device-vs-host metadata parity (covers default routing, 0-recv, K-tail, wider experts)
+    parity_cases = [
+        dict(name="baseline", M=256, H=512, I=1024, G=2 * ws, topk=2, capacity=float(ws), routing="random"),
+        dict(name="skew_rank0", M=128, H=512, I=512, G=2 * ws, topk=2, capacity=float(ws), routing="skew_rank0"),
+        dict(name="ktail", M=200, H=328, I=520, G=2 * ws, topk=2, capacity=float(ws), routing="random"),
+        dict(name="more_experts", M=128, H=512, I=512, G=4 * ws, topk=4, capacity=float(ws), routing="random"),
+    ]
+
     if args.no_check:
         if rank == 0:
             print("--no-check: skipping correctness checks", flush=True)
     else:
-        for i, c in enumerate(cases):
-            run_case(args, EP_GROUP, rank, world_size, device, case_seed=i, **c)
+        if rank == 0:
+            print("== metadata parity (device vs host) ==", flush=True)
+        for i, c in enumerate(parity_cases):
+            run_metadata_parity(args, EP_GROUP, rank, world_size, device, case_seed=1000 + i, **c)
+        run_local_splits_alias_regression(args, EP_GROUP, rank, world_size, device)
+        run_invalid_id_regression(args, EP_GROUP, rank, world_size, device)
+        run_combine_autofollow_regression(args, EP_GROUP, rank, world_size, device)
+        run_precomputed_meta_bad_idx_regression(args, EP_GROUP, rank, world_size, device)
+        # run the full suite once per metadata path: device (default) then host fallback
+        for mode in ("device", "host"):
+            use_dev = (mode == "device")
+            if rank == 0:
+                print(f"== forward suite (metadata={mode}) ==", flush=True)
+            for i, c in enumerate(cases):
+                run_case(args, EP_GROUP, rank, world_size, device, case_seed=i, use_device_metadata=use_dev, **c)
         print(f"RANK[{rank}]: all checks passed.", flush=True)
         torch.distributed.barrier(EP_GROUP)
         if rank == 0:

--- a/python/triton_dist/test/amd/test_ep_a2a_fused_kernel.py
+++ b/python/triton_dist/test/amd/test_ep_a2a_fused_kernel.py
@@ -39,9 +39,13 @@ its own context; all ranks run the same sequence so collectives stay matched):
   - capacity    : capacity too small -> every rank must raise a clear RuntimeError
 
 Usage (mori_shmem; RCCL on this firmware requires HSA_NO_SCRATCH_RECLAIM=1):
+  1. For 4-GPU run
     HIP_VISIBLE_DEVICES=4,5,6,7 ARNOLD_WORKER_GPU=4 \\
     TRITON_DIST_SHMEM_BACKEND=mori_shmem HSA_NO_SCRATCH_RECLAIM=1 \\
-    bash ./scripts/launch_amd.sh ./python/triton_dist/test/amd/test_ep_a2a_fused.py
+    bash ./scripts/launch_amd.sh ./python/triton_dist/test/amd/test_ep_a2a_fused_kernel.py
+  2. For 8-GPU run
+    TRITON_DIST_SHMEM_BACKEND=mori_shmem HSA_NO_SCRATCH_RECLAIM=1 \\
+    bash ./scripts/launch_amd.sh ./python/triton_dist/test/amd/test_ep_a2a_fused_kernel.py
 """
 
 import os

--- a/python/triton_dist/test/amd/test_ep_moe_fused.py
+++ b/python/triton_dist/test/amd/test_ep_moe_fused.py
@@ -1,0 +1,347 @@
+################################################################################
+#
+# Copyright (c) 2025 ByteDance Ltd. and/or its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+################################################################################
+"""
+Layer / function -level test for the AMD fused EP MoE.
+
+Drives the layer ``layers/amd.EpAll2AllFusedOp`` and the functional / autograd
+entries ``function/amd.{fused_ep_moe, fused_ep_moe_autograd,
+TritonDistFusedEpMoeFunction}``, checking correctness against a single-process
+PyTorch reference.
+
+The default config family (only ``ntokens`` varies) is used to:
+  1. run the fused MoE forward (``fused_ep_moe``) and check it against the
+     reference (every rank holds the full expert table; the fused path only uses
+     this rank's local expert slice);
+  2. benchmark forward latency / peak memory (``benchmark_latency_memory``);
+  3. (once) assert the autograd Function raises ``NotImplementedError`` on backward.
+
+It then runs extra correctness cases (each builds/tears down its own op) covering
+layer plumbing the default loop does not: ungated (``routing_weights=None``),
+fp16, non-multiple tail dims, the decomposed 3-stage API
+(``preprocess`` -> ``mega_dispatch_group_gemm`` -> ``mega_group_gemm_combine``),
+0-recv skew, and capacity overflow (expects ``RuntimeError``).
+
+The process exits non-zero if any correctness check fails.
+
+Routing uses distinct valid top-k expert ids; weights are this rank's local expert
+slices (``w1=[epr,hidden,inter]``, ``w2=[epr,inter,hidden]``).
+
+Usage (mori_shmem; RCCL on this firmware requires HSA_NO_SCRATCH_RECLAIM=1):
+  1. For 4-GPU run
+    HIP_VISIBLE_DEVICES=4,5,6,7 ARNOLD_WORKER_GPU=4 \\
+    TRITON_DIST_SHMEM_BACKEND=mori_shmem HSA_NO_SCRATCH_RECLAIM=1 \\
+    bash ./scripts/launch_amd.sh ./python/triton_dist/test/amd/test_ep_moe_fused.py
+  2. For 8-GPU run
+    TRITON_DIST_SHMEM_BACKEND=mori_shmem HSA_NO_SCRATCH_RECLAIM=1 \\
+    bash ./scripts/launch_amd.sh ./python/triton_dist/test/amd/test_ep_moe_fused.py
+"""
+
+import argparse
+import math
+import os
+import sys
+
+os.environ.setdefault("TRITON_DIST_SHMEM_BACKEND", "mori_shmem")
+os.environ.setdefault("MORI_SHMEM_HEAP_SIZE", "4G")
+
+_test_dir = os.path.dirname(os.path.abspath(__file__))
+_workspace_root = os.path.abspath(os.path.join(_test_dir, "../../../.."))
+_triton_dist_python_path = os.path.join(_workspace_root, "python")
+if _triton_dist_python_path not in sys.path:
+    sys.path.insert(0, _triton_dist_python_path)
+_current_pythonpath = os.environ.get("PYTHONPATH", "")
+if _triton_dist_python_path not in _current_pythonpath:
+    os.environ["PYTHONPATH"] = (f"{_triton_dist_python_path}:{_current_pythonpath}"
+                                if _current_pythonpath else _triton_dist_python_path)
+_triton_python_path = os.path.join(_workspace_root, "3rdparty/triton/python")
+if os.path.exists(_triton_python_path):
+    sys.path.insert(0, _triton_python_path)
+
+import torch
+import torch.distributed
+
+from triton_dist.utils import initialize_distributed, finalize_distributed
+from triton_dist.profiler_utils import benchmark_latency_memory, print_benchmark_comparison
+from triton_dist.layers.amd.ep_a2a_fused_layer import EpAll2AllFusedOp
+from triton_dist.function.amd.ep_moe_fused import (
+    fused_ep_moe,
+    fused_ep_moe_autograd,
+    TritonDistFusedEpMoeFunction,
+)
+
+DTYPE_MAP = {"bfloat16": torch.bfloat16, "float16": torch.float16, "float32": torch.float32}
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="AMD fused EP MoE layer/function test")
+    p.add_argument("--dtype", default="bfloat16", choices=list(DTYPE_MAP.keys()), help="Data type")
+    p.add_argument("--warmup", type=int, default=5, help="Warmup iterations")
+    p.add_argument("--iters", type=int, default=10, help="Benchmark iterations")
+    p.add_argument("--seed", type=int, default=42, help="Random seed")
+    p.add_argument("--ntokens", default=4096, type=int, help="Max total number of tokens (across ranks)")
+    p.add_argument("--hidden_dim", default=1024, type=int, help="Hidden dimension")
+    p.add_argument("--ffn_dim", default=1024, type=int, help="FFN intermediate dimension")
+    p.add_argument("--topk", default=4, type=int, help="Top-K experts per token")
+    p.add_argument("--num_experts", default=16, type=int, help="Total number of experts")
+    p.add_argument("--num_ranks", type=int, default=None, help="Number of EP ranks (default: WORLD_SIZE)")
+    p.add_argument("--capacity", type=float, default=None,
+                   help="Expert-group capacity (default: world_size, the worst-case safe value)")
+    p.add_argument("--atol", type=float, default=2e-2, help="Correctness atol")
+    p.add_argument("--rtol", type=float, default=2e-2, help="Correctness rtol")
+    p.add_argument("--no-check", dest="no_check", action="store_true", help="Skip correctness checks")
+    p.add_argument("--no-bench", dest="no_bench", action="store_true", help="Skip benchmarking")
+    p.add_argument("--no-extra-cases", dest="no_extra_cases", action="store_true",
+                   help="Skip the extra correctness cases (ungated/fp16/tail/decomposed/skew/capacity)")
+    return p.parse_args()
+
+
+def uniform_split_tokens(ntokens, nsplits):
+    """Uniformly split tokens across ranks."""
+    ret = [ntokens // nsplits for _ in range(nsplits)]
+    ret[-1] = ntokens - sum(ret[:-1])
+    assert all(x >= 0 for x in ret)
+    return ret
+
+
+def make_weights(num_experts, hidden, inter, world_size, rank, dtype, device, seed):
+    """Full expert tables (identical on every rank via a fixed seed) + this rank's local slice.
+
+    AMD layout: ``W1=[E, hidden, inter]`` (up), ``W2=[E, inter, hidden]`` (down).
+    """
+    g = torch.Generator(device=device).manual_seed(seed)
+    W1 = (torch.randn(num_experts, hidden, inter, generator=g, device=device, dtype=torch.float32) *
+          (1.0 / hidden)**0.5).to(dtype)
+    W2 = (torch.randn(num_experts, inter, hidden, generator=g, device=device, dtype=torch.float32) *
+          (1.0 / inter)**0.5).to(dtype)
+    epr = num_experts // world_size
+    w1_local = W1[rank * epr:(rank + 1) * epr].contiguous()
+    w2_local = W2[rank * epr:(rank + 1) * epr].contiguous()
+    return W1, W2, w1_local, w2_local
+
+
+def gen_routing(routing, n, num_experts, topk, epr, device, g):
+    """Top-k expert ids per token. ``random`` = distinct ids via top-k over random logits;
+    ``skew_rank0`` = every token -> rank-0's first ``topk`` experts (other ranks get 0 recv)."""
+    if routing == "skew_rank0":
+        assert topk <= epr, "skew_rank0 needs topk <= experts_per_rank"
+        return torch.arange(topk, device=device, dtype=torch.int32).unsqueeze(0).expand(n, topk).contiguous()
+    logits = torch.rand(n, num_experts, generator=g, device=device)
+    return torch.topk(logits, k=topk, dim=-1).indices.to(torch.int32)
+
+
+def prepare_inputs(n, hidden, num_experts, topk, dtype, device, seed):
+    """Per-rank activations: hidden states, distinct top-k expert ids, routing weights."""
+    g = torch.Generator(device=device).manual_seed(seed)
+    hidden_states = (torch.randn(n, hidden, generator=g, device=device, dtype=torch.float32) * 0.5).to(dtype)
+    expert_index = gen_routing("random", n, num_experts, topk, num_experts, device, g)
+    gate_weights = torch.rand(n, topk, generator=g, device=device, dtype=torch.float32) + 0.5
+    return hidden_states, expert_index, gate_weights
+
+
+def ref_moe(x, idx, weights, W1, W2):
+    """out[t] = sum_j w[t,j] * relu(x[t] @ W1[e]) @ W2[e]  (model-dtype matmul, fp32 reduce)."""
+    T, k = idx.shape
+    H = x.shape[1]
+    flat_e = idx.reshape(-1).long()
+    xe = x.repeat_interleave(k, dim=0)
+    h = torch.relu(torch.bmm(xe.unsqueeze(1), W1[flat_e]).squeeze(1))
+    y = torch.bmm(h.unsqueeze(1), W2[flat_e]).squeeze(1)
+    y = y.float() * weights.reshape(-1, 1).float()
+    return y.reshape(T, k, H).sum(dim=1).to(x.dtype)
+
+
+def run_layer_case(args, EP_GROUP, rank, world_size, device, *, case_idx, name, hidden, ffn, topk, experts, dtype, n,
+                   gated=True, decomposed=False, capacity=None, routing="random", expect_capacity_error=False):
+    """Build a dedicated op for one correctness case, run it, compare to the torch reference,
+    and return the cross-rank-agreed pass flag. (Each case has its own op / shape / dtype.)"""
+    dt = DTYPE_MAP[dtype]
+    epr = experts // world_size
+    cap = float(world_size) if capacity is None else capacity
+    W1, W2, w1l, w2l = make_weights(experts, hidden, ffn, world_size, rank, dt, device, seed=args.seed + 17 * case_idx)
+    layer = EpAll2AllFusedOp(EP_GROUP, max_tokens=n, hidden=hidden, topk=topk, num_tot_experts=experts, dtype=dt,
+                             capacity=cap)
+    g = torch.Generator(device=device).manual_seed(args.seed + 1000 * case_idx + rank + 1)
+    hs = (torch.randn(n, hidden, generator=g, device=device, dtype=torch.float32) * 0.5).to(dt)
+    idx = gen_routing(routing, n, experts, topk, epr, device, g)
+    weights = torch.rand(n, topk, generator=g, device=device, dtype=torch.float32) + 0.5
+    ok = True
+    try:
+        if expect_capacity_error:
+            raised = False
+            try:
+                fused_ep_moe(layer, hs, idx, w1l, w2l, routing_weights=weights)
+            except RuntimeError as e:
+                raised = "cap_tokens" in str(e) or "capacity" in str(e)
+            ok = raised
+        else:
+            ref = ref_moe(hs, idx, weights if gated else torch.ones_like(weights), W1, W2)
+            gate = weights if gated else None
+            if decomposed:
+                desc = layer.preprocess(idx)
+                g1, desc = layer.mega_dispatch_group_gemm(hs, idx, desc, w1l)
+                out = layer.mega_group_gemm_combine(torch.relu(g1).contiguous(), w2l, desc, gate_input=gate)
+            else:
+                out = fused_ep_moe(layer, hs, idx, w1l, w2l, routing_weights=gate)
+            torch.cuda.synchronize()
+            ok = out.shape == ref.shape
+            if ok:
+                try:
+                    torch.testing.assert_close(out.float(), ref.float(), atol=args.atol, rtol=args.rtol)
+                except AssertionError:
+                    ok = False
+    finally:
+        layer.finalize()
+    flag = torch.tensor([1 if ok else 0], device=device, dtype=torch.int32)
+    torch.distributed.all_reduce(flag, op=torch.distributed.ReduceOp.MIN, group=EP_GROUP)
+    ok = bool(flag.item())
+    if rank == 0:
+        print(f"  [case {name}] {'PASS' if ok else 'FAIL'}", flush=True)
+    return ok
+
+
+def main():
+    args = parse_args()
+    torch.manual_seed(args.seed)
+
+    EP_GROUP = initialize_distributed()
+    rank = EP_GROUP.rank()
+    world_size = EP_GROUP.size()
+    num_ranks = args.num_ranks if args.num_ranks is not None else world_size
+    assert num_ranks == world_size, "num_ranks must equal WORLD_SIZE"
+    assert args.num_experts % world_size == 0, "num_experts must be divisible by world_size"
+    device = torch.cuda.current_device()
+    dtype = DTYPE_MAP[args.dtype]
+    capacity = float(world_size) if args.capacity is None else args.capacity
+
+    H, I, topk, G = args.hidden_dim, args.ffn_dim, args.topk, args.num_experts
+
+    # token configs (total tokens), filtered to <= --ntokens
+    base = [512, 1024, 2048, 4096, 8192]
+    ntokens_list = [t for t in base if t <= args.ntokens] or [args.ntokens]
+    max_per_rank = max(int(math.ceil(t / num_ranks)) for t in ntokens_list)
+
+    if rank == 0:
+        print(f"AMD MoE Test: hidden={H}, ffn={I}, topk={topk}, num_experts={G}, ranks={num_ranks}, "
+              f"dtype={dtype}, capacity={capacity}, ntokens_list={ntokens_list}\n", flush=True)
+
+    # full expert tables (identical across ranks) + this rank's local slice
+    W1, W2, w1_local, w2_local = make_weights(G, H, I, world_size, rank, dtype, device, seed=args.seed)
+
+    # one fused op, reused across configs (only token count varies)
+    layer = EpAll2AllFusedOp(EP_GROUP, max_tokens=max_per_rank, hidden=H, topk=topk, num_tot_experts=G, dtype=dtype,
+                             capacity=capacity)
+
+    all_implementations = {}
+    global_ok = True
+    try:
+        for ntokens in ntokens_list:
+            token_splits = uniform_split_tokens(ntokens, num_ranks)
+            n = token_splits[rank]
+            hidden_states, expert_index, gate_weights = prepare_inputs(
+                n, H, G, topk, dtype, device, seed=args.seed + 1000 + rank + 7 * ntokens)
+            torch.distributed.barrier(EP_GROUP)
+
+            precision = "N/A"
+            if not args.no_check:
+                ref = ref_moe(hidden_states, expert_index, gate_weights, W1, W2)
+                out = fused_ep_moe(layer, hidden_states, expert_index, w1_local, w2_local,
+                                   routing_weights=gate_weights)
+                torch.cuda.synchronize()
+                ok = out.shape == ref.shape
+                if ok:
+                    try:
+                        torch.testing.assert_close(out.float(), ref.float(), atol=args.atol, rtol=args.rtol)
+                    except AssertionError:
+                        ok = False
+                # agree across ranks (min over the 0/1 flags)
+                flag = torch.tensor([1 if ok else 0], device=device, dtype=torch.int32)
+                torch.distributed.all_reduce(flag, op=torch.distributed.ReduceOp.MIN, group=EP_GROUP)
+                ok = bool(flag.item())
+                precision = ok
+                global_ok = global_ok and ok
+
+            latency, memory = 0.0, 0.0
+            if not args.no_bench:
+                def fwd():
+                    return fused_ep_moe(layer, hidden_states, expert_index, w1_local, w2_local,
+                                        routing_weights=gate_weights)
+
+                latency, memory = benchmark_latency_memory(fwd, args.iters, args.warmup)
+
+            all_implementations[(ntokens, H, I)] = {
+                "amd_fused_ep_moe_fwd": {"latency": latency, "memory": memory, "precision": precision},
+            }
+            if rank == 0:
+                print(f"  config ntokens={ntokens} (n/rank={n}): precision={precision} "
+                      f"latency={latency:.3f}ms mem={memory:.2f}MB", flush=True)
+
+        # backward must raise NotImplementedError (check once)
+        if not args.no_check:
+            hs = hidden_states.clone().detach().requires_grad_(True)
+            out_ag = fused_ep_moe_autograd(layer, hs, expert_index, w1_local, w2_local, routing_weights=gate_weights)
+            raised = False
+            try:
+                out_ag.float().sum().backward()
+            except NotImplementedError:
+                raised = True
+            assert raised, "TritonDistFusedEpMoeFunction.backward must raise NotImplementedError"
+            assert TritonDistFusedEpMoeFunction is not None
+            torch.distributed.barrier(EP_GROUP)
+            if rank == 0:
+                print("  backward NotImplementedError: raised as expected", flush=True)
+    finally:
+        layer.finalize()
+
+    # extra correctness cases (each builds/tears down its own op)
+    if not args.no_check and not args.no_extra_cases:
+        extra_cases = [
+            dict(name="ungated", hidden=512, ffn=512, topk=2, experts=2 * num_ranks, dtype=args.dtype, n=128,
+                 gated=False),
+            dict(name="fp16", hidden=512, ffn=512, topk=2, experts=2 * num_ranks, dtype="float16", n=128),
+            dict(name="tail_dims", hidden=1000, ffn=600, topk=2, experts=2 * num_ranks, dtype=args.dtype, n=96),
+            dict(name="decomposed_api", hidden=512, ffn=512, topk=2, experts=2 * num_ranks, dtype=args.dtype, n=128,
+                 decomposed=True),
+            dict(name="skew_rank0", hidden=512, ffn=512, topk=2, experts=2 * num_ranks, dtype=args.dtype, n=96,
+                 routing="skew_rank0"),
+            dict(name="capacity_overflow", hidden=256, ffn=256, topk=2, experts=2 * num_ranks, dtype=args.dtype,
+                 n=256, capacity=0.25, expect_capacity_error=True),
+        ]
+        for i, c in enumerate(extra_cases):
+            global_ok = run_layer_case(args, EP_GROUP, rank, num_ranks, device, case_idx=i + 1, **c) and global_ok
+
+    if rank == 0:
+        print_benchmark_comparison(all_implementations, "AMD Fused EP MoE (forward)",
+                                   param_names=["Ntokens", "Hidden", "FFN"],
+                                   title_params={"topk": topk, "num_experts": G})
+        if not args.no_check:
+            print("\n✅ all close!" if global_ok else "\n❌ correctness FAILED", flush=True)
+
+    finalize_distributed()
+    if not args.no_check and not global_ok:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds an AMD (ROCm / mori_shmem) port of the fused Expert-Parallel all-to-all + grouped-GEMM MoE **forward** — the AMD counterpart of the NVIDIA `ep_all2all_fused` stack. It covers the full **three-layer forward stack** (kernel → layer → function).

**1. Kernel** (`kernels/amd/ep_all2all_fused.py`)
Two persistent "mega kernels" that fuse token communication with the expert GEMMs and overlap them at tile granularity, mirroring the NVIDIA kernel:
```
x[T,H] ──(mega A) dispatch + grouped GEMM-1 (up)──► [M,I]
       ── relu ──► ──(mega B) grouped GEMM-2 (down) + combine──► out[T,H]
```
Cross-rank communication and synchronization use mori (`putmem_warp` / `signal_op` / `signal_wait_until` / `barrier_all_block`). The cross-rank split / recv-offset and grouped-GEMM tiling metadata are **built on-device by default**, with a host-torch path (one `all_gather`) kept as a fallback.

**2. Layer** (`layers/amd/ep_a2a_fused_layer.py`)
`EpAll2AllFusedOp(nn.Module)`, mirroring NVIDIA's `EpAll2AllFusedOp` API. It reuses the mega kernels and threads a single precomputed `meta` through preprocess → dispatch → combine.

**3. Function** (`function/amd/ep_moe_fused.py`)
Model-facing entries: `fused_ep_moe` (functional) and `TritonDistFusedEpMoeFunction` (`torch.autograd.Function`, forward) / `fused_ep_moe_autograd`.

**Scope: intra-node, forward-only.**

## Not implemented (future work)
`backward` raises `NotImplementedError` — this is a forward-only stack. Compared with the NVIDIA fused MoE stack, the following are not ported yet:
- scatter-combine (push) mode (serial/gather combine only);
- two-stage (tail-SM / local-checkpoint) dispatch;
- backward / transposed grouped GEMM (autograd backward);
- lazy symmetric allocator + dynamic output-buffer resize + multi comm buffer (this PR uses a fixed `capacity` and raises a clear `RuntimeError` on overflow).

## Test
Both suites run on free GPUs (pick idle cards via `rocm-smi`; RCCL on this firmware requires `HSA_NO_SCRATCH_RECLAIM=1`).

**Kernel-level** — `test/amd/test_ep_a2a_fused_kernel.py`. Checks the full fused forward against the PyTorch reference `out[t] = Σ_j w[t,j]·relu(x[t]@w1[e])@w2[e]` over 10 cases (topk ∈ {1,2,4,8}, epr ∈ {2,4}, bf16/fp16, K/M/N tails, 0-recv skew, ungated, partial tokens, capacity overflow), for both metadata backends (device + host fallback):
```bash
TRITON_DIST_SHMEM_BACKEND=mori_shmem HSA_NO_SCRATCH_RECLAIM=1 \
bash ./scripts/launch_amd.sh ./python/triton_dist/test/amd/test_ep_a2a_fused_kernel.py
```

**Layer/function-level** — `test/amd/test_ep_moe_fused.py` (mirrors `test/nvidia/test_ep_moe_fused.py`). Drives `EpAll2AllFusedOp` + `fused_ep_moe` against the same reference, benchmarks the forward, and asserts `backward` raises `NotImplementedError`, plus extra cases (ungated, fp16, etc. — see the test file):
```bash
TRITON_DIST_SHMEM_BACKEND=mori_shmem HSA_NO_SCRATCH_RECLAIM=1 \
bash ./scripts/launch_amd.sh ./python/triton_dist/test/amd/test_ep_moe_fused.py
```

Validated on 4× and 8× MI300X (gfx942 / ROCm / mori_shmem): both suites pass (`✅ all close!`).
