### PR TITLE
feat: Add Ascend RDMA support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,5 +13,5 @@
 	update = none
 [submodule "3rdparty/triton-ascend"]
 	path = 3rdparty/triton-ascend
-	url = https://gitcode.com/Ascend/triton-ascend.git
+	url = https://github.com/triton-lang/triton-ascend.git
 	update = none

--- a/docs/build.md
+++ b/docs/build.md
@@ -141,7 +141,7 @@ See examples in the `tutorials` directory at the project root.
 ## To use Triton-distributed with the AMD backend:
 Starting from the rocm/pytorch:rocm7.1_ubuntu24.04_py3.12_pytorch_release_2.7.1 Docker container
 #### AMD Build Steps
-0. Detect your GPU architecture and export it. 
+0. Detect your GPU architecture and export it.
 ```sh
 # e.g. gfx950 for MI350, gfx942 for MI300
 python3 -c "import torch; print(torch.cuda.get_device_properties(0).gcnArchName.split(':')[0])"
@@ -201,8 +201,8 @@ git clone https://github.com/ByteDance-Seed/Triton-distributed.git
 ```sh
 cd Triton-distributed/
 git submodule update --init --depth=1
-# 3rdparty/triton-ascend and 3rdparty/shmem are hosted on gitcode.com and are
-# marked `update = none` in .gitmodules, so the command above skips them (this
+# 3rdparty/shmem and 3rdparty/triton-ascend's submodules are hosted on gitcode.com and
+# are marked `update = none` in .gitmodules, so the command above skips them (this
 # keeps CI environments that cannot reach gitcode.com from failing at submodule
 # init). Fetch them explicitly for an Ascend build (--checkout overrides `none`):
 git submodule update --init --checkout --depth=1 3rdparty/triton-ascend 3rdparty/shmem
@@ -266,8 +266,8 @@ triton-ascend depends on specified LLVM version
   ```
 4. Build Triton-distributed
 ```sh
-cd {PATH_TO}/Triton-distributed/python
-LLVM_SYSPATH=${LLVM_INSTALL_PREFIX} TRITON_BUILD_WITH_CLANG_LLD=ON TRITON_BUILD_PROTON=OFF TRITON_BUILD_LITTLE_KERNEL=OFF TRITON_USE_ASCEND=ON TRITON_APPEND_CMAKE_ARGS="-DTRITON_BUILD_UT=OFF" python setup.py install
+cd {PATH_TO}/Triton-distributed
+LLVM_SYSPATH=${LLVM_INSTALL_PREFIX} TRITON_BUILD_WITH_CLANG_LLD=ON TRITON_BUILD_PROTON=OFF TRITON_BUILD_LITTLE_KERNEL=OFF TRITON_USE_ASCEND=ON TRITON_APPEND_CMAKE_ARGS="-DTRITON_BUILD_UT=OFF" pip install ./python
 ```
 
 5. Build and Install shmem

--- a/include/TritonDistributed/Conversion/TritonDistributedToHIVM/TritonDistributedToHIVMPass.h
+++ b/include/TritonDistributed/Conversion/TritonDistributedToHIVM/TritonDistributedToHIVMPass.h
@@ -37,9 +37,6 @@ static const llvm::SmallVector<std::string> mixTypeList = {
     "aclshmem_barrier_all"};
 static const llvm::SmallVector<std::string> vecTypeList = {
     "aclshmemx_barrier_all_vec"};
-static const llvm::SmallVector<std::string> sideEffectSymbols = {
-    "aclshmemx_barrier_all_vec", "aclshmem_barrier_all", "aclshmem_int8_p",
-    "aclshmem_int16_p",          "aclshmem_int32_p",     "aclshmem_int64_p"};
 static const llvm::DenseMap<llvm::StringRef, hivm::PIPE> pipeMap;
 static const int distributedDialectPrefixLen = 12;
 void populateDistributedOpToHIVMPatterns(RewritePatternSet &patterns,

--- a/lib/Conversion/TritonDistributedToHIVM/ASCEND/DistributedOpToHIVM.cpp
+++ b/lib/Conversion/TritonDistributedToHIVM/ASCEND/DistributedOpToHIVM.cpp
@@ -32,6 +32,7 @@
 #include "mlir/IR/Value.h"
 #include "mlir/IR/ValueRange.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/Triton/IR/Types.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
@@ -200,6 +201,21 @@ public:
     if (!hasSideEffect) {
       customOp->setAttr("no_side_effect", rewriter.getUnitAttr());
     }
+    llvm::SmallVector<int> gmAddrArgsIndices;
+    auto funcOp = customOp->template getParentOfType<triton::FuncOp>();
+    assert(funcOp && "custom op should be in tt.func op");
+    for (auto &&[idx, operand] : llvm::enumerate(customOp->getOperands())) {
+      if (!llvm::isa<triton::PointerType>(operand.getType())) {
+        continue;
+      }
+      if (auto arg = llvm::dyn_cast<BlockArgument>(operand)) {
+        if (arg.getOwner() == &funcOp.getFunctionBody().front()) {
+          gmAddrArgsIndices.emplace_back(idx);
+        }
+      }
+    }
+    customOp->setAttr("gm_addr_args_indices",
+                      rewriter.getDenseI32ArrayAttr(gmAddrArgsIndices));
     // Replace the original op with the custom op
     if (op->getNumResults() == 0) {
       rewriter.eraseOp(op);

--- a/lib/Conversion/TritonDistributedToHIVM/ASCEND/DistributedOpToHIVM.cpp
+++ b/lib/Conversion/TritonDistributedToHIVM/ASCEND/DistributedOpToHIVM.cpp
@@ -31,6 +31,7 @@
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/IR/Value.h"
 #include "mlir/IR/ValueRange.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "triton/Dialect/Triton/IR/Types.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
@@ -123,7 +124,7 @@ public:
     if (auto sym = op->template getAttrOfType<StringAttr>("symbol")) {
       symbolName = sym.str();
     }
-    bool hasSideEffect = true;
+    bool hasSideEffect = !mlir::isMemoryEffectFree(op.getOperation());
 
     llvm::TypeSwitch<Operation *, void>(op)
         .Case([&](distributed::SymmAtOp) {
@@ -159,9 +160,6 @@ public:
     if (symbolName.empty()) {
       symbolName = op->getName().getStringRef().drop_front(
           ASCEND::distributedDialectPrefixLen);
-    }
-    if (!llvm::is_contained(ASCEND::sideEffectSymbols, symbolName)) {
-      hasSideEffect = false;
     }
     std::string customName = customPrefix + "." + symbolName;
     ValueRange operands = op->getOperands();

--- a/python/triton_dist/jit.py
+++ b/python/triton_dist/jit.py
@@ -209,6 +209,9 @@ def get_shmem_extern_lib() -> Dict[str, str]:
         extern_libs = {"libshmem": str(mxshmem_lib)}
         return extern_libs
 
+    elif is_ascend():
+        return {}
+
     else:
         raise NotImplementedError("Unsupported device type to get shmem bitcode lib path.")
 

--- a/python/triton_dist/language/__init__.py
+++ b/python/triton_dist/language/__init__.py
@@ -38,7 +38,13 @@ from .smem_ops import (
     get_smem_shared_address_u32,
     smem_dealloc,
 )
-from . import tma
+
+# TMA (Tensor Memory Accelerator) is NVIDIA/CUDA-specific
+from triton_dist.utils import is_cuda
+if is_cuda():
+    from . import tma
+else:
+    tma = None
 
 __all__ = [
     # distributed ops

--- a/python/triton_dist/language/extra/ascend/libaclshmem_device.py
+++ b/python/triton_dist/language/extra/ascend/libaclshmem_device.py
@@ -283,6 +283,7 @@ def _putmem_signal_impl(
     op: core.constexpr,
     _semantic=None,
 ):
+    tl.static_assert(sig_addr.dtype == pi_i32_t, "sig_addr should be a pointer of pi_i32_t", _semantic=_semantic)
     return extern_call(
         "libshmem_device",
         "",
@@ -290,7 +291,7 @@ def _putmem_signal_impl(
             dest,
             source,
             tl.cast(nbytes, tl.uint32, _semantic=_semantic),
-            sig_addr,
+            tl.cast(sig_addr, pi_i32_t, _semantic=_semantic),
             tl.cast(signal, tl.int32, _semantic=_semantic),
             tl.cast(sig_op, tl.int32, _semantic=_semantic),
             tl.cast(pe, tl.int32, _semantic=_semantic),
@@ -299,7 +300,7 @@ def _putmem_signal_impl(
             core.pointer_type(core.dtype(core_dtype)),
             core.pointer_type(core.dtype(core_dtype)),
             tl.uint32,
-            core.pointer_type(core.dtype("int32")),
+            pi_i32_t,
             tl.int32,
             tl.int32,
             tl.int32,
@@ -345,11 +346,12 @@ def putmem_signal_nbi(dest, source, nbytes, sig_addr, signal, sig_op, pe, _seman
 
 @core.extern
 def signal_op(sig_addr, signal, sig_op, pe, _semantic=None):
+    tl.static_assert(sig_addr.dtype == pi_i32_t, "sig_addr should be a pointer of pi_i32_t", _semantic=_semantic)
     return extern_call(
         "libshmem_device",
         "",
         [
-            sig_addr,
+            tl.cast(sig_addr, pi_i32_t, _semantic=_semantic),
             tl.cast(signal, tl.int32, _semantic=_semantic),
             tl.cast(sig_op, tl.int32, _semantic=_semantic),
             tl.cast(pe, tl.int32, _semantic=_semantic),
@@ -367,11 +369,12 @@ def signal_op(sig_addr, signal, sig_op, pe, _semantic=None):
 
 @core.extern
 def signal_wait_until(sig_addr, cmp_, cmp_val, _semantic=None):
+    tl.static_assert(sig_addr.dtype == pi_i32_t, "sig_addr should be a pointer of pi_i32_t", _semantic=_semantic)
     return extern_call(
         "libshmem_device",
         "",
         [
-            sig_addr,
+            tl.cast(sig_addr, pi_i32_t, _semantic=_semantic),
             tl.cast(cmp_, tl.int32, _semantic=_semantic),
             tl.cast(cmp_val, tl.int32, _semantic=_semantic),
         ],

--- a/python/triton_dist/language/extra/ascend/libaclshmem_device.py
+++ b/python/triton_dist/language/extra/ascend/libaclshmem_device.py
@@ -5,8 +5,54 @@ import triton.language as tl
 from triton_dist.language.core import extern_call
 
 pi_u64_t = tl.core.pointer_type(tl.core.dtype("uint64"))
+pi_i32_t = tl.core.pointer_type(tl.core.dtype("int32"))
 
 void_ptr = core.pointer_type(core.void)
+
+# The subset of dtypes supported by Ascend SHMEM RMA ops.
+RMA_DTYPES = [
+    "fp16",
+    "fp32",
+    "int8",
+    "int16",
+    "int32",
+    "int64",
+    "uint8",
+    "uint16",
+    "uint32",
+    "uint64",
+    "bf16",
+]
+
+DTYPE_TO_KERNEL_SUFFIX = {
+    "fp16": "half",
+    "fp32": "float",
+    "int8": "int8",
+    "int16": "int16",
+    "int32": "int32",
+    "int64": "int64",
+    "uint8": "uint8",
+    "uint16": "uint16",
+    "uint32": "uint32",
+    "uint64": "uint64",
+    "bf16": "bfloat16",
+}
+
+
+def _pointer_type_hash(self):
+    return hash((self.name, self.element_ty, "tt_ptr"))
+
+
+def patch_hash_method_for_pointer_type():
+    elem_dtype_list = (tl.core.dtype.SINT_TYPES + tl.core.dtype.UINT_TYPES + tl.core.dtype.FP_TYPES +
+                       tl.core.dtype.OTHER_TYPES)
+    for elem_dtype in elem_dtype_list:
+        ptr_ty = type(tl.core.pointer_type(tl.core.dtype(elem_dtype)))
+        ptr_ty.__hash__ = _pointer_type_hash
+
+
+# Keep pointer_type hashable for Triton extern signature dict keys.
+patch_hash_method_for_pointer_type()
 
 
 @core.extern
@@ -31,6 +77,55 @@ def n_pes(_semantic=None):
         [],
         {
             (): ("aclshmem_n_pes", core.dtype("int32")),
+        },
+        is_pure=True,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def team_my_pe(team, _semantic=None):
+    return extern_call(
+        "libshmem_device",
+        "",
+        [tl.cast(team, tl.int32, _semantic=_semantic)],
+        {
+            (tl.int32, ): ("aclshmem_team_my_pe", core.dtype("int32")),
+        },
+        is_pure=True,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def team_n_pes(team, _semantic=None):
+    return extern_call(
+        "libshmem_device",
+        "",
+        [tl.cast(team, tl.int32, _semantic=_semantic)],
+        {
+            (tl.int32, ): ("aclshmem_team_n_pes", core.dtype("int32")),
+        },
+        is_pure=True,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def team_translate_pe(src_team, pe_in_src_team, dest_team, _semantic=None):
+    return extern_call(
+        "libshmem_device",
+        "",
+        [
+            tl.cast(src_team, tl.int32, _semantic=_semantic),
+            tl.cast(pe_in_src_team, tl.int32, _semantic=_semantic),
+            tl.cast(dest_team, tl.int32, _semantic=_semantic),
+        ],
+        {
+            (tl.int32, tl.int32, tl.int32): (
+                "aclshmem_team_translate_pe",
+                core.dtype("int32"),
+            ),
         },
         is_pure=True,
         _semantic=_semantic,
@@ -96,6 +191,223 @@ def barrier_all_vec(_semantic=None):
         [],
         {
             (): ("aclshmemx_barrier_all_vec", ()),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def barrier(team, _semantic=None):
+    return extern_call(
+        "libshmem_device",
+        "",
+        [tl.cast(team, tl.int32, _semantic=_semantic)],
+        {
+            (tl.int32, ): ("aclshmem_barrier", ()),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def barrier_vec(team, _semantic=None):
+    return extern_call(
+        "libshmem_device",
+        "",
+        [tl.cast(team, tl.int32, _semantic=_semantic)],
+        {
+            (tl.int32, ): ("aclshmemx_barrier_vec", ()),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def _rma_mem_impl(dest, source, elem_size, pe, op: core.constexpr, _semantic=None):
+    return extern_call(
+        "libshmem_device",
+        "",
+        [
+            dest,
+            source,
+            tl.cast(elem_size, tl.uint32, _semantic=_semantic),
+            tl.cast(pe, tl.int32, _semantic=_semantic),
+        ],
+        {(
+            core.pointer_type(core.dtype(core_dtype)),
+            core.pointer_type(core.dtype(core_dtype)),
+            tl.uint32,
+            tl.int32,
+        ): (
+             f"aclshmem_{DTYPE_TO_KERNEL_SUFFIX[core_dtype]}_{op.value}",
+             (),
+         )
+         for core_dtype in RMA_DTYPES},
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def getmem(dest, source, bytes, pe, _semantic=None):
+    return _rma_mem_impl(dest, source, bytes, pe, core.constexpr("getmem"), _semantic=_semantic)
+
+
+@core.extern
+def putmem(dest, source, bytes, pe, _semantic=None):
+    return _rma_mem_impl(dest, source, bytes, pe, core.constexpr("putmem"), _semantic=_semantic)
+
+
+@core.extern
+def getmem_nbi(dest, source, bytes, pe, qp_id=0, _semantic=None):
+    return _rma_mem_impl(dest, source, bytes, pe, core.constexpr("getmem_nbi"), _semantic=_semantic)
+
+
+@core.extern
+def putmem_nbi(dest, source, bytes, pe, qp_id=0, _semantic=None):
+    return _rma_mem_impl(dest, source, bytes, pe, core.constexpr("putmem_nbi"), _semantic=_semantic)
+
+
+@core.extern
+def _putmem_signal_impl(
+    dest,
+    source,
+    nbytes,
+    sig_addr,
+    signal,
+    sig_op,
+    pe,
+    op: core.constexpr,
+    _semantic=None,
+):
+    return extern_call(
+        "libshmem_device",
+        "",
+        [
+            dest,
+            source,
+            tl.cast(nbytes, tl.uint32, _semantic=_semantic),
+            sig_addr,
+            tl.cast(signal, tl.int32, _semantic=_semantic),
+            tl.cast(sig_op, tl.int32, _semantic=_semantic),
+            tl.cast(pe, tl.int32, _semantic=_semantic),
+        ],
+        {(
+            core.pointer_type(core.dtype(core_dtype)),
+            core.pointer_type(core.dtype(core_dtype)),
+            tl.uint32,
+            core.pointer_type(core.dtype("int32")),
+            tl.int32,
+            tl.int32,
+            tl.int32,
+        ): (
+             f"aclshmem_{DTYPE_TO_KERNEL_SUFFIX[core_dtype]}_{op.value}",
+             (),
+         )
+         for core_dtype in RMA_DTYPES},
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def putmem_signal(dest, source, nbytes, sig_addr, signal, sig_op, pe, _semantic=None):
+    return _putmem_signal_impl(
+        dest,
+        source,
+        nbytes,
+        sig_addr,
+        signal,
+        sig_op,
+        pe,
+        core.constexpr("putmem_signal"),
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def putmem_signal_nbi(dest, source, nbytes, sig_addr, signal, sig_op, pe, _semantic=None):
+    return _putmem_signal_impl(
+        dest,
+        source,
+        nbytes,
+        sig_addr,
+        signal,
+        sig_op,
+        pe,
+        core.constexpr("putmem_signal_nbi"),
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def signal_op(sig_addr, signal, sig_op, pe, _semantic=None):
+    return extern_call(
+        "libshmem_device",
+        "",
+        [
+            sig_addr,
+            tl.cast(signal, tl.int32, _semantic=_semantic),
+            tl.cast(sig_op, tl.int32, _semantic=_semantic),
+            tl.cast(pe, tl.int32, _semantic=_semantic),
+        ],
+        {
+            (pi_i32_t, tl.int32, tl.int32, tl.int32): (
+                "aclshmemx_signal_op",
+                (),
+            ),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def signal_wait_until(sig_addr, cmp_, cmp_val, _semantic=None):
+    return extern_call(
+        "libshmem_device",
+        "",
+        [
+            sig_addr,
+            tl.cast(cmp_, tl.int32, _semantic=_semantic),
+            tl.cast(cmp_val, tl.int32, _semantic=_semantic),
+        ],
+        {
+            (pi_i32_t, tl.int32, tl.int32): (
+                "aclshmem_signal_wait_until",
+                tl.int32,
+            ),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def quiet(_semantic=None):
+    return extern_call(
+        "libshmem_device",
+        "",
+        [],
+        {
+            (): ("aclshmem_quiet", ()),
+        },
+        is_pure=False,
+        _semantic=_semantic,
+    )
+
+
+@core.extern
+def fence(_semantic=None):
+    return extern_call(
+        "libshmem_device",
+        "",
+        [],
+        {
+            (): ("aclshmem_fence", ()),
         },
         is_pure=False,
         _semantic=_semantic,

--- a/python/triton_dist/language/extra/ascend/libaclshmem_device.py
+++ b/python/triton_dist/language/extra/ascend/libaclshmem_device.py
@@ -3,6 +3,7 @@
 from triton.language import core
 import triton.language as tl
 from triton_dist.language.core import extern_call
+from triton_dist.language.extra.utils import patch_hash_method_for_pointer_type
 
 pi_u64_t = tl.core.pointer_type(tl.core.dtype("uint64"))
 pi_i32_t = tl.core.pointer_type(tl.core.dtype("int32"))
@@ -38,20 +39,6 @@ DTYPE_TO_KERNEL_SUFFIX = {
     "bf16": "bfloat16",
 }
 
-
-def _pointer_type_hash(self):
-    return hash((self.name, self.element_ty, "tt_ptr"))
-
-
-def patch_hash_method_for_pointer_type():
-    elem_dtype_list = (tl.core.dtype.SINT_TYPES + tl.core.dtype.UINT_TYPES + tl.core.dtype.FP_TYPES +
-                       tl.core.dtype.OTHER_TYPES)
-    for elem_dtype in elem_dtype_list:
-        ptr_ty = type(tl.core.pointer_type(tl.core.dtype(elem_dtype)))
-        ptr_ty.__hash__ = _pointer_type_hash
-
-
-# Keep pointer_type hashable for Triton extern signature dict keys.
 patch_hash_method_for_pointer_type()
 
 

--- a/python/triton_dist/language/extra/cuda/libnvshmem_device.py
+++ b/python/triton_dist/language/extra/cuda/libnvshmem_device.py
@@ -25,24 +25,12 @@
 from triton.language import core
 import triton.language as tl
 from triton_dist.language.core import extern_call
+from triton_dist.language.extra.utils import patch_hash_method_for_pointer_type
 import sys
 
 pi_u64_t = tl.core.pointer_type(tl.core.dtype("uint64"))
 pi_i64_t = tl.core.pointer_type(tl.core.dtype("int64"))
 
-
-def _pointer_type_hash(self):
-    return hash((self.name, self.element_ty, "tt_ptr"))
-
-
-def patch_hash_method_for_pointer_type():
-    elem_dtype_list = tl.core.dtype.SINT_TYPES + tl.core.dtype.UINT_TYPES + tl.core.dtype.FP_TYPES + tl.core.dtype.OTHER_TYPES
-    for elem_dtype in elem_dtype_list:
-        ptr_ty = type(tl.core.pointer_type(tl.core.dtype(elem_dtype)))
-        ptr_ty.__hash__ = _pointer_type_hash
-
-
-# apply monkey patch in runtime
 patch_hash_method_for_pointer_type()
 
 # class nvshmemi_cmp_type(Enum):

--- a/python/triton_dist/language/extra/hip/libmori_shmem_device.py
+++ b/python/triton_dist/language/extra/hip/libmori_shmem_device.py
@@ -25,7 +25,10 @@
 from triton.language import core
 import triton.language as tl
 from triton_dist.language.core import extern_call
+from triton_dist.language.extra.utils import patch_hash_method_for_pointer_type
 import sys
+
+patch_hash_method_for_pointer_type()
 
 pi_u64_t = tl.core.pointer_type(tl.core.dtype("uint64"))
 pi_i64_t = tl.core.pointer_type(tl.core.dtype("int64"))

--- a/python/triton_dist/language/extra/hip/librocshmem_device.py
+++ b/python/triton_dist/language/extra/hip/librocshmem_device.py
@@ -25,6 +25,9 @@
 from triton.language import core
 import triton.language as tl
 from triton_dist.language.core import extern_call
+from triton_dist.language.extra.utils import patch_hash_method_for_pointer_type
+
+patch_hash_method_for_pointer_type()
 
 pi_u64_t = tl.core.pointer_type(tl.core.dtype("uint64"))
 pi_i64_t = tl.core.pointer_type(tl.core.dtype("int64"))

--- a/python/triton_dist/language/extra/libshmem_device.py
+++ b/python/triton_dist/language/extra/libshmem_device.py
@@ -22,457 +22,452 @@
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 ################################################################################
-from .utils import ModuleProxy
-from triton_dist.utils import is_ascend, is_cuda, is_rocshmem, is_mori_shmem, is_maca
-
-proxy_list = []
-if is_cuda():
-    import triton_dist.language.extra.cuda.libnvshmem_device as libnvshmem_device
-    proxy_list.append((is_cuda, libnvshmem_device))
-if is_rocshmem():
-    import triton_dist.language.extra.hip.librocshmem_device as librocshmem_device
-    proxy_list.append((is_rocshmem, librocshmem_device))
-if is_mori_shmem():
-    import triton_dist.language.extra.hip.libmori_shmem_device as libmori_shmem_device
-    proxy_list.append((is_mori_shmem, libmori_shmem_device))
-if is_maca():
-    import triton_dist.language.extra.maca.libmxshmem_device as libmxshmem_device
-    proxy_list.append((is_maca, libmxshmem_device))
-if is_ascend():
-    import triton_dist.language.extra.ascend.libaclshmem_device as libaclshmem_device
-    proxy_list.append((is_ascend, libaclshmem_device))
-
 import sys
+from importlib import import_module
+
+from .utils import ModuleProxy
+from triton_dist.utils import is_ascend, is_cuda, is_maca, is_mori_shmem, is_rocshmem
+
+_BACKENDS = (
+    (is_cuda, "triton_dist.language.extra.cuda.libnvshmem_device"),
+    (is_rocshmem, "triton_dist.language.extra.hip.librocshmem_device"),
+    (is_mori_shmem, "triton_dist.language.extra.hip.libmori_shmem_device"),
+    (is_maca, "triton_dist.language.extra.maca.libmxshmem_device"),
+    (is_ascend, "triton_dist.language.extra.ascend.libaclshmem_device"),
+)
+
+proxy_list = [(predicate, import_module(module_name)) for predicate, module_name in _BACKENDS if predicate()]
 
 _shmem_module = ModuleProxy(proxy_list)
 
 
 @_shmem_module.dispatch
-def set_rocshmem_ctx(ctx, _semantic=None):
+def set_rocshmem_ctx(ctx):
     """ROCSHMEM only"""
     ...
 
 
 @_shmem_module.dispatch
-def my_pe(_semantic=None):
+def my_pe():
     """Both NVSHMEM and ROCSHMEM"""
     ...
 
 
 @_shmem_module.dispatch
-def n_pes(_semantic=None):
+def n_pes():
     """Both NVSHMEM and ROCSHMEM"""
     ...
 
 
 @_shmem_module.dispatch
-def team_my_pe(team, _semantic=None):
+def team_my_pe(team):
     ...
 
 
 @_shmem_module.dispatch
-def team_n_pes(team, _semantic=None):
+def team_n_pes(team):
     ...
 
 
 @_shmem_module.dispatch
-def int_p(dest, value, pe, qp_id=0, _semantic=None):
+def int_p(dest, value, pe, qp_id=0):
     """Both NVSHMEM and ROCSHMEM"""
     ...
 
 
 @_shmem_module.dispatch
-def remote_ptr(local_ptr, pe, _semantic=None):
+def remote_ptr(local_ptr, pe):
     """Both NVSHMEM and ROCSHMEM"""
     ...
 
 
 @_shmem_module.dispatch
-def remote_mc_ptr(team, ptr, _semantic=None):
+def remote_mc_ptr(team, ptr):
     ...
 
 
 @_shmem_module.dispatch
-def barrier_all(_semantic=None):
+def barrier_all():
     ...
 
 
 @_shmem_module.dispatch
-def barrier_all_vec(_semantic=None):
+def barrier_all_vec():
+    """ACLSHMEM only"""
     ...
 
 
 @_shmem_module.dispatch
-def barrier_all_block(_semantic=None):
+def barrier_all_block():
     ...
 
 
 @_shmem_module.dispatch
-def barrier_all_warp(_semantic=None):
+def barrier_all_warp():
     ...
 
 
 @_shmem_module.dispatch
-def barrier_all_wave(_semantic=None):
+def barrier_all_wave():
     ...
 
 
 @_shmem_module.dispatch
-def barrier_all_wg(_semantic=None):
+def barrier_all_wg():
     ...
 
 
 @_shmem_module.dispatch
-def barrier(team, _semantic=None):
+def barrier(team):
     ...
 
 
 @_shmem_module.dispatch
-def barrier_block(team, _semantic=None):
+def barrier_block(team):
     ...
 
 
 @_shmem_module.dispatch
-def barrier_warp(team, _semantic=None):
+def barrier_warp(team):
     ...
 
 
 @_shmem_module.dispatch
-def sync_all(_semantic=None):
+def sync_all():
     ...
 
 
 @_shmem_module.dispatch
-def sync_all_block(_semantic=None):
+def sync_all_block():
     ...
 
 
 @_shmem_module.dispatch
-def sync_all_warp(_semantic=None):
+def sync_all_warp():
     ...
 
 
 @_shmem_module.dispatch
-def team_sync_block(team, _semantic=None):
+def team_sync_block(team):
     ...
 
 
 @_shmem_module.dispatch
-def team_sync_warp(team, _semantic=None):
+def team_sync_warp(team):
     ...
 
 
 @_shmem_module.dispatch
-def quiet(_semantic=None):
+def quiet():
     ...
 
 
 @_shmem_module.dispatch
-def quiet_pe(_semantic=None):
+def quiet_pe():
     ...
 
 
 @_shmem_module.dispatch
-def fence(_semantic=None):
+def fence():
     ...
 
 
 @_shmem_module.dispatch
-def getmem_nbi_block(dest, source, bytes, pe, _semantic=None):
+def getmem_nbi_block(dest, source, bytes, pe):
     ...
 
 
 @_shmem_module.dispatch
-def getmem_block(dest, source, bytes, pe, _semantic=None):
+def getmem_block(dest, source, bytes, pe):
     ...
 
 
 @_shmem_module.dispatch
-def getmem_nbi_warp(dest, source, bytes, pe, _semantic=None):
+def getmem_nbi_warp(dest, source, bytes, pe):
     ...
 
 
 @_shmem_module.dispatch
-def getmem_warp(dest, source, bytes, pe, _semantic=None):
+def getmem_warp(dest, source, bytes, pe):
     ...
 
 
 @_shmem_module.dispatch
-def getmem_nbi(dest, source, bytes, pe, _semantic=None):
+def getmem_nbi(dest, source, bytes, pe):
     ...
 
 
 @_shmem_module.dispatch
-def getmem_nbi_wave(dest, source, bytes, pe, _semantic=None):
+def getmem_nbi_wave(dest, source, bytes, pe):
     ...
 
 
 @_shmem_module.dispatch
-def getmem_nbi_wg(dest, source, bytes, pe, _semantic=None):
+def getmem_nbi_wg(dest, source, bytes, pe):
     ...
 
 
 @_shmem_module.dispatch
-def getmem(dest, source, bytes, pe, _semantic=None):
+def getmem(dest, source, bytes, pe):
     ...
 
 
 @_shmem_module.dispatch
-def getmem_wave(dest, source, bytes, pe, _semantic=None):
+def getmem_wave(dest, source, bytes, pe):
     ...
 
 
 @_shmem_module.dispatch
-def getmem_wg(dest, source, bytes, pe, _semantic=None):
+def getmem_wg(dest, source, bytes, pe):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_block(dest, source, bytes, pe, _semantic=None):
+def putmem_block(dest, source, bytes, pe):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_nbi_block(dest, source, bytes, pe, _semantic=None):
+def putmem_nbi_block(dest, source, bytes, pe):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_warp(dest, source, bytes, pe, _semantic=None):
+def putmem_warp(dest, source, bytes, pe):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_nbi_warp(dest, source, bytes, pe, _semantic=None):
+def putmem_nbi_warp(dest, source, bytes, pe):
     ...
 
 
 @_shmem_module.dispatch
-def putmem(dest, source, bytes, pe, _semantic=None):
+def putmem(dest, source, bytes, pe):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_wave(dest, source, bytes, pe, _semantic=None):
+def putmem_wave(dest, source, bytes, pe):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_wg(dest, source, bytes, pe, _semantic=None):
+def putmem_wg(dest, source, bytes, pe):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_nbi(dest, source, bytes, pe, qp_id=0, _semantic=None):
+def putmem_nbi(dest, source, bytes, pe, qp_id=0):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_nbi_wave(dest, source, bytes, pe, _semantic=None):
+def putmem_nbi_wave(dest, source, bytes, pe):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_nbi_wg(dest, source, bytes, pe, _semantic=None):
+def putmem_nbi_wg(dest, source, bytes, pe):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_nbi(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
+def putmem_signal_nbi(dest, source, bytes, sig_addr, signal, sig_op, pe):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
+def putmem_signal(dest, source, bytes, sig_addr, signal, sig_op, pe):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_nbi_block(dest, source, bytes, sig_addr, signal, sig_op, pe, qp_id=0, _semantic=None):
+def putmem_signal_nbi_block(dest, source, bytes, sig_addr, signal, sig_op, pe, qp_id=0):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_block(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
+def putmem_signal_block(dest, source, bytes, sig_addr, signal, sig_op, pe):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_nbi_warp(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
+def putmem_signal_nbi_warp(dest, source, bytes, sig_addr, signal, sig_op, pe):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_warp(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
+def putmem_signal_warp(dest, source, bytes, sig_addr, signal, sig_op, pe):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_wave(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
+def putmem_signal_wave(dest, source, bytes, sig_addr, signal, sig_op, pe):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_wg(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
+def putmem_signal_wg(dest, source, bytes, sig_addr, signal, sig_op, pe):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_nbi_wave(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
+def putmem_signal_nbi_wave(dest, source, bytes, sig_addr, signal, sig_op, pe):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_nbi_wg(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
+def putmem_signal_nbi_wg(dest, source, bytes, sig_addr, signal, sig_op, pe):
     ...
 
 
 @_shmem_module.dispatch
-def signal_op(sig_addr, signal, sig_op, pe, _semantic=None):
+def signal_op(sig_addr, signal, sig_op, pe):
     ...
 
 
 @_shmem_module.dispatch
-def signal_wait_until(sig_addr, cmp_, cmp_val, _semantic=None):
+def signal_wait_until(sig_addr, cmp_, cmp_val):
     ...
 
 
 @_shmem_module.dispatch
-def uint64_wait_until_equals(addr, val, _semantic=None):
+def uint64_wait_until_equals(addr, val):
     ...
 
 
 @_shmem_module.dispatch
-def ulong_put_signal(dest, source, nelems, sig_addr, signal, sig_op, pe, _semantic=None):
+def ulong_put_signal(dest, source, nelems, sig_addr, signal, sig_op, pe):
     ...
 
 
 # DON'T USE THIS. NVSHMEM 3.2.5 does not implement this
 @_shmem_module.dispatch
-def broadcastmem(team, dest, source, nelems, pe_root, _semantic=None):
+def broadcastmem(team, dest, source, nelems, pe_root):
     ...
 
 
 @_shmem_module.dispatch
-def broadcastmem_warp(team, dest, source, nelems, pe_root, _semantic=None):
+def broadcastmem_warp(team, dest, source, nelems, pe_root):
     ...
 
 
 @_shmem_module.dispatch
-def broadcastmem_block(team, dest, source, nelems, pe_root, _semantic=None):
+def broadcastmem_block(team, dest, source, nelems, pe_root):
     ...
 
 
 @_shmem_module.dispatch
-def broadcast(team, dest, source, nelems, pe_root, _semantic=None):
+def broadcast(team, dest, source, nelems, pe_root):
     ...
 
 
 @_shmem_module.dispatch
-def broadcast_warp(team, dest, source, nelems, pe_root, _semantic=None):
+def broadcast_warp(team, dest, source, nelems, pe_root):
     ...
 
 
 @_shmem_module.dispatch
-def broadcast_block(team, dest, source, nelems, pe_root, _semantic=None):
+def broadcast_block(team, dest, source, nelems, pe_root):
     ...
 
 
 # DON'T USE THIS. NVSHMEM 3.2.5 does not implement this
 @_shmem_module.dispatch
-def fcollectmem(team, dest, source, nelems, _semantic=None):
+def fcollectmem(team, dest, source, nelems):
     ...
 
 
 @_shmem_module.dispatch
-def fcollectmem_warp(team, dest, source, nelems, _semantic=None):
+def fcollectmem_warp(team, dest, source, nelems):
     ...
 
 
 @_shmem_module.dispatch
-def fcollectmem_block(team, dest, source, nelems, _semantic=None):
+def fcollectmem_block(team, dest, source, nelems):
     ...
 
 
 @_shmem_module.dispatch
-def fcollect(team, dest, source, nelems, _semantic=None):
+def fcollect(team, dest, source, nelems):
     ...
 
 
 @_shmem_module.dispatch
-def fcollect_warp(team, dest, source, nelems, _semantic=None):
+def fcollect_warp(team, dest, source, nelems):
     ...
 
 
 @_shmem_module.dispatch
-def fcollect_block(team, dest, source, nelems, _semantic=None):
+def fcollect_block(team, dest, source, nelems):
     ...
 
 
 ### putmem_rma_* and putmem_signal_rma_* requires nvshmemi_* APIs. and you have to compile the .bc file yourself with shmem/nvshmem_bind/nvshmemi/build_nvshmemi_bc.sh
 @_shmem_module.dispatch
-def putmem_rma(dest, source, bytes, pe, _semantic=None):
+def putmem_rma(dest, source, bytes, pe):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_rma_block(dest, source, bytes, pe, _semantic=None):
+def putmem_rma_block(dest, source, bytes, pe):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_rma_warp(dest, source, bytes, pe, _semantic=None):
+def putmem_rma_warp(dest, source, bytes, pe):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_rma_nbi(dest, source, bytes, pe, _semantic=None):
+def putmem_rma_nbi(dest, source, bytes, pe):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_rma_nbi_block(dest, source, bytes, pe, _semantic=None):
+def putmem_rma_nbi_block(dest, source, bytes, pe):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_rma_nbi_warp(dest, source, bytes, pe, _semantic=None):
+def putmem_rma_nbi_warp(dest, source, bytes, pe):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_rma(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
+def putmem_signal_rma(dest, source, bytes, sig_addr, signal, sig_op, pe):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_rma_nbi(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
+def putmem_signal_rma_nbi(dest, source, bytes, sig_addr, signal, sig_op, pe):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_rma_warp(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
+def putmem_signal_rma_warp(dest, source, bytes, sig_addr, signal, sig_op, pe):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_rma_nbi_warp(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
+def putmem_signal_rma_nbi_warp(dest, source, bytes, sig_addr, signal, sig_op, pe):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_rma_block(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
+def putmem_signal_rma_block(dest, source, bytes, sig_addr, signal, sig_op, pe):
     ...
 
 
 @_shmem_module.dispatch
-def putmem_signal_rma_nbi_block(dest, source, bytes, sig_addr, signal, sig_op, pe, _semantic=None):
+def putmem_signal_rma_nbi_block(dest, source, bytes, sig_addr, signal, sig_op, pe):
     ...
 
 
 # TEAM translate
 @_shmem_module.dispatch
-def team_translate_pe(src_team, pe_in_src_team, dest_team, _semantic=None):
+def team_translate_pe(src_team, pe_in_src_team, dest_team):
     ...
 
 

--- a/python/triton_dist/language/extra/libshmem_device.py
+++ b/python/triton_dist/language/extra/libshmem_device.py
@@ -123,6 +123,12 @@ def barrier(team):
 
 
 @_shmem_module.dispatch
+def barrier_vec(team):
+    """ACLSHMEM Only"""
+    ...
+
+
+@_shmem_module.dispatch
 def barrier_block(team):
     ...
 
@@ -565,3 +571,19 @@ MORI_AMO_FETCH_XOR = 19
 MORI_AMO_SWAP = 20
 MORI_AMO_COMPARE_SWAP = 21
 MORI_AMO_OP_SENTINEL = sys.maxsize
+
+# aclshmem_team_t
+ACLSHMEM_TEAM_INVALID = -1
+ACLSHMEM_TEAM_WORLD = 0
+
+# aclshmem_cmp_op_type_t
+ACLSHMEM_CMP_EQ = 0
+ACLSHMEM_CMP_NE = 1
+ACLSHMEM_CMP_GT = 2
+ACLSHMEM_CMP_GE = 3
+ACLSHMEM_CMP_LT = 4
+ACLSHMEM_CMP_LE = 5
+
+# aclshmem_signal_op_type_t
+ACLSHMEM_SIGNAL_SET = 0
+ACLSHMEM_SIGNAL_ADD = 1

--- a/python/triton_dist/language/extra/maca/libmxshmem_device.py
+++ b/python/triton_dist/language/extra/maca/libmxshmem_device.py
@@ -26,7 +26,10 @@
 from triton.language import core
 import triton.language as tl
 from triton_dist.language.core import extern_call
+from triton_dist.language.extra.utils import patch_hash_method_for_pointer_type
 import sys
+
+patch_hash_method_for_pointer_type()
 
 pi_u64_t = tl.core.pointer_type(tl.core.dtype("uint64"))
 

--- a/python/triton_dist/language/extra/utils.py
+++ b/python/triton_dist/language/extra/utils.py
@@ -22,6 +22,7 @@
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 ################################################################################
+import inspect
 from typing import Dict, Callable, Any
 from functools import wraps
 from triton.language import core
@@ -47,11 +48,23 @@ class ModuleProxy:
         delattr(self._module, name)
 
     def dispatch(self, func: Callable) -> Any:
+        func_signature = inspect.signature(func)
+        parameters = list(func_signature.parameters.values())
+        if "_semantic" not in func_signature.parameters:
+            parameters.append(inspect.Parameter(
+                "_semantic",
+                inspect.Parameter.KEYWORD_ONLY,
+                default=None,
+            ))
 
         @core.builtin
         @wraps(func)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args, _semantic=None, **kwargs):
             method = getattr(self._module, func.__name__)
+            if "_semantic" in inspect.signature(method).parameters:
+                kwargs["_semantic"] = _semantic
             return method(*args, **kwargs)
+
+        wrapper.__signature__ = func_signature.replace(parameters=parameters)
 
         return wrapper

--- a/python/triton_dist/language/extra/utils.py
+++ b/python/triton_dist/language/extra/utils.py
@@ -28,6 +28,18 @@ from functools import wraps
 from triton.language import core
 
 
+def _pointer_type_hash(self):
+    return hash((self.name, self.element_ty, "tt_ptr"))
+
+
+def patch_hash_method_for_pointer_type():
+    # Triton pointer_type defines __eq__ but not __hash__, so dict keys fail.
+    elem_dtype_list = (core.dtype.SINT_TYPES + core.dtype.UINT_TYPES + core.dtype.FP_TYPES + core.dtype.OTHER_TYPES)
+    for elem_dtype in elem_dtype_list:
+        ptr_ty = type(core.pointer_type(core.dtype(elem_dtype)))
+        ptr_ty.__hash__ = _pointer_type_hash
+
+
 class ModuleProxy:
 
     def __init__(self, module_list: Dict[Callable, Any]):

--- a/python/triton_dist/test/ascend/conftest.py
+++ b/python/triton_dist/test/ascend/conftest.py
@@ -6,20 +6,30 @@ import torch.distributed as dist
 import torch.multiprocessing as mp
 
 
+def pytest_configure(config):
+    config.addinivalue_line("markers", "dist: mark distributed Ascend tests")
+
+
 def _worker_wrapper(rank, world_size, backend, fn, args, error_queue):
     """
     Common entry point for each worker process.
     Exits normally on success; on failure, pushes the exception into error_queue.
     """
-    os.environ["MASTER_ADDR"] = "localhost"
-    os.environ["MASTER_PORT"] = "29500"
+    os.environ.setdefault("MASTER_ADDR", "localhost")
+    os.environ.setdefault("MASTER_PORT", "29500")
+    os.environ["RANK"] = str(rank)
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
     try:
         torch.npu.set_device(rank)
         dist.init_process_group(
             backend=backend,
+            init_method="env://",
             rank=rank,
             world_size=world_size,
+            device_id=torch.device(f"npu:{torch.npu.current_device()}"),
         )
+        dist.barrier()
         fn(rank, world_size, *args)
     except Exception as e:
         error_queue.put((rank, e))

--- a/python/triton_dist/test/ascend/test_barrier_ops.py
+++ b/python/triton_dist/test/ascend/test_barrier_ops.py
@@ -1,0 +1,193 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+import pytest
+import torch
+import shmem as ash
+import torch.distributed as dist
+import triton
+import triton.language as tl
+from triton.language.extra.cann.extension import sub_vec_id
+from triton_dist.language.extra import libshmem_device
+
+G_ASH_SIZE = 1024 * 1024 * 1024
+G_IP_PORT = "tcp://127.0.0.1:8666"
+
+
+def _init_aclshmem(rank, world_size):
+    ret = ash.set_conf_store_tls(False, "")
+    if ret != 0:
+        raise ValueError("[ERROR] set_conf_store_tls failed")
+    attributes = ash.InitAttr()
+    attributes.my_rank = rank
+    attributes.n_ranks = world_size
+    attributes.local_mem_size = G_ASH_SIZE
+    attributes.ip_port = G_IP_PORT
+    attributes.option_attr.data_op_engine_type = ash.OpEngineType.MTE
+    ret = ash.aclshmem_init(attributes)
+    if ret != 0:
+        raise ValueError("[ERROR] aclshmem_init failed")
+
+
+@triton.jit
+def _increase_with_barrier_kernel(counter_ptr, team):
+    team_rank = libshmem_device.team_my_pe(team)
+
+    if team_rank >= 0:
+        team_size = libshmem_device.team_n_pes(team)
+        val = tl.load(counter_ptr)
+
+        libshmem_device.barrier(team)
+
+        if sub_vec_id() == 0:
+            next_team_rank = (team_rank + 1) % team_size
+            next_pe = libshmem_device.team_translate_pe(
+                team,
+                next_team_rank,
+                libshmem_device.ACLSHMEM_TEAM_WORLD,
+            )
+            remote = libshmem_device.remote_ptr(counter_ptr, next_pe)
+            tl.store(remote, val + 1)
+
+        libshmem_device.barrier(team)
+
+
+@triton.jit
+def _increase_with_barrier_all_kernel(counter_ptr, my_rank: tl.constexpr, world_size: tl.constexpr):
+    val = tl.load(counter_ptr)
+
+    libshmem_device.barrier_all()
+
+    if sub_vec_id() == 0:
+        next_pe = (my_rank + 1) % world_size
+        remote = libshmem_device.remote_ptr(counter_ptr, next_pe)
+        tl.store(remote, val + 1)
+
+    libshmem_device.barrier_all()
+
+
+@triton.jit
+def _increase_with_barrier_vec_kernel(counter_ptr, team):
+    team_rank = libshmem_device.team_my_pe(team)
+
+    if team_rank >= 0:
+        team_size = libshmem_device.team_n_pes(team)
+        val = tl.load(counter_ptr)
+
+        libshmem_device.barrier_vec(team)
+
+        if sub_vec_id() == 0:
+            next_team_rank = (team_rank + 1) % team_size
+            next_pe = libshmem_device.team_translate_pe(
+                team,
+                next_team_rank,
+                libshmem_device.ACLSHMEM_TEAM_WORLD,
+            )
+            remote = libshmem_device.remote_ptr(counter_ptr, next_pe)
+            tl.store(remote, val + 1)
+
+        libshmem_device.barrier_vec(team)
+
+
+@triton.jit
+def _increase_with_barrier_all_vec_kernel(counter_ptr, my_rank: tl.constexpr, world_size: tl.constexpr):
+    val = tl.load(counter_ptr)
+
+    libshmem_device.barrier_all_vec()
+
+    if sub_vec_id() == 0:
+        next_pe = (my_rank + 1) % world_size
+        remote = libshmem_device.remote_ptr(counter_ptr, next_pe)
+        tl.store(remote, val + 1)
+
+    libshmem_device.barrier_all_vec()
+
+
+def _run_team_increase_test(rank, kernel_fn, team, expected):
+    counter = ash.aclshmem_create_tensor([1], dtype=torch.int64, device_id=rank)
+    try:
+        counter.zero_()
+        dist.barrier()
+        kernel_fn[(1, 1, 1)](counter, team)
+        dist.barrier()
+        actual = counter.cpu().item()
+        assert actual == expected, (f"Rank {rank}: expected counter {expected}, got {actual}")
+    finally:
+        ash.aclshmem_free_tensor(counter)
+
+
+def _run_world_increase_test(rank, world_size, kernel_fn, *kernel_args):
+    counter = ash.aclshmem_create_tensor([1], dtype=torch.int64, device_id=rank)
+    try:
+        counter.zero_()
+        dist.barrier()
+        kernel_fn[(1, 1, 1)](counter, *kernel_args, rank, world_size)
+        dist.barrier()
+        actual = counter.cpu().item()
+        assert actual == 1, f"Rank {rank}: expected counter 1, got {actual}"
+    finally:
+        ash.aclshmem_free_tensor(counter)
+
+
+def _create_odd_sub_team(world_size):
+    return ash.team_split_strided(
+        libshmem_device.ACLSHMEM_TEAM_WORLD,
+        1,
+        2,
+        world_size // 2,
+    )
+
+
+def _test_team_world_barriers(rank, world_size):
+    team = libshmem_device.ACLSHMEM_TEAM_WORLD
+
+    _run_team_increase_test(rank, _increase_with_barrier_kernel, team, expected=1)
+    print(f"Rank {rank}: aclshmem_barrier (TEAM_WORLD) OK")
+
+    _run_world_increase_test(rank, world_size, _increase_with_barrier_all_kernel)
+    print(f"Rank {rank}: aclshmem_barrier_all OK")
+
+    _run_team_increase_test(rank, _increase_with_barrier_vec_kernel, team, expected=1)
+    print(f"Rank {rank}: aclshmemx_barrier_vec (TEAM_WORLD) OK")
+
+    _run_world_increase_test(rank, world_size, _increase_with_barrier_all_vec_kernel)
+    print(f"Rank {rank}: aclshmemx_barrier_all_vec OK")
+
+
+def _test_odd_sub_team_barriers(rank, world_size):
+    team_odd = _create_odd_sub_team(world_size)
+    try:
+        # Odd ranks are members of team_split_strided(TEAM_WORLD, 1, 2, world_size // 2).
+        expected = 1 if rank % 2 == 1 else 0
+
+        _run_team_increase_test(rank, _increase_with_barrier_kernel, team_odd, expected)
+        print(f"Rank {rank}: aclshmem_barrier (odd sub-team) "
+              f"{'OK' if expected else 'skipped (not in team)'}")
+
+        _run_team_increase_test(rank, _increase_with_barrier_vec_kernel, team_odd, expected)
+        print(f"Rank {rank}: aclshmemx_barrier_vec (odd sub-team) "
+              f"{'OK' if expected else 'skipped (not in team)'}")
+    finally:
+        ash.team_destroy(team_odd)
+
+
+def run_test_team_world(rank, world_size):
+    _init_aclshmem(rank, world_size)
+    _test_team_world_barriers(rank, world_size)
+    _ = ash.aclshmem_finalize()
+
+
+def run_test_sub_team(rank, world_size):
+    _init_aclshmem(rank, world_size)
+    _test_team_world_barriers(rank, world_size)
+    dist.barrier()
+    _test_odd_sub_team_barriers(rank, world_size)
+    _ = ash.aclshmem_finalize()
+
+
+@pytest.mark.dist
+def test_barrier_ops_team_world(dist_test):
+    dist_test(run_test_team_world, world_size=2)
+
+
+@pytest.mark.dist
+def test_barrier_ops_sub_team(dist_test):
+    dist_test(run_test_sub_team, world_size=4)

--- a/python/triton_dist/test/ascend/test_gm_addr_args_indices.py
+++ b/python/triton_dist/test/ascend/test_gm_addr_args_indices.py
@@ -1,0 +1,225 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+#
+# Licensed under the MIT License.
+#
+# This test constructs MLIR IR containing distributed dialect operators as strings,
+# calls add_convert_triton_distributed_to_hivm to convert them to hivm.custom,
+# and verifies that the gm_addr_args_indices attribute on each custom operator is correct.
+# Pure IR-level test, does not require NPU hardware.
+#
+# gm_addr_args_indices records operand indices in custom operators that are:
+#   1. Of type triton::PointerType (scalar !tt.ptr<T>);
+#   2. Function entry block arguments (tt.func parameters).
+# Tensor pointers (tensor<...x!tt.ptr<T>>), pointers that are not function parameters
+# (such as results from tt.addptr), and non-pointer operands should not appear in it.
+#
+# Note: conftest.py in this directory imports torch at the top level. In environments
+# without NPU driver installed, set TORCH_DEVICE_BACKEND_AUTOLOAD=0 before running.
+# This test itself does not depend on torch or NPU driver.
+
+import re
+import tempfile
+import os
+
+from triton._C import libtriton
+
+
+def _make_context():
+    """Construct an MLIRContext with all relevant dialects loaded."""
+    ir = libtriton.ir
+    distributed = libtriton.distributed
+    ascend = libtriton.ascend
+    ctx = ir.context()
+    ctx.disable_multithreading()
+    ir.load_dialects(ctx)  # triton + built-in dialect
+    distributed.ir.load_dialects(ctx)  # distributed dialect
+    ascend.ir.load_dialects(ctx)  # hivm + annotation + scope
+    ascend.load_dialects(ctx)  # triton ascend dialect
+    return ctx
+
+
+def _parse(ctx, ir_str):
+    """Construct IR from string, write to temp file and parse as module."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".mlir", delete=False) as f:
+        f.write(ir_str)
+        path = f.name
+    try:
+        return libtriton.ir.parse_mlir_module(path, ctx)
+    finally:
+        os.unlink(path)
+
+
+def _run_pass(module, ctx):
+    """Run the distributed -> hivm conversion pass on the module."""
+    pm = libtriton.ir.pass_manager(ctx)
+    libtriton.distributed.ascend_passes.ttgpuir.add_convert_triton_distributed_to_hivm(pm)
+    pm.run(module)
+
+
+def _extract_gm_addr_indices(module_str):
+    """Extract symbol and gm_addr_args_indices from each hivm.custom operator in printed IR.
+
+    Returns [(symbol, [indices...]), ...] in order of appearance.
+    """
+    results = []
+    for line in module_str.splitlines():
+        if "hir.custom" not in line:
+            continue
+        sym_match = re.search(r'symbol = "([^"]+)"', line)
+        idx_match = re.search(r"gm_addr_args_indices = array<i32([^>]*)>", line)
+        symbol = sym_match.group(1) if sym_match else "?"
+        if not idx_match:
+            indices = None  # attribute missing
+        else:
+            body = idx_match.group(1)
+            # shaped like ": 0, 1" or "" (empty array)
+            body = body.lstrip(":").strip()
+            if body:
+                indices = [int(x.strip()) for x in body.split(",")]
+            else:
+                indices = []
+        results.append((symbol, indices))
+    return results
+
+
+# An IR segment containing multiple distributed operators:
+#   %arg0 : !tt.ptr<f32>  -- function parameter, scalar pointer, used as sigAddr for notify, should be captured
+#   %arg1 : i32           -- function parameter, non-pointer, should not be captured
+#   %arg2 : !tt.ptr<i32>  -- function parameter, scalar pointer, used as barrierPtr for wait, should be captured
+#   %arg3 : !tt.ptr<f32>  -- function parameter, scalar pointer, used as symmAddr for symm_at, should be captured
+#   %addptr               -- tt.addptr result, pointer but not a function parameter, used as input for consume_token,
+#                            should not be captured (verify non-parameter pointers are excluded).
+# Results of each operator are consumed by tt.store to avoid being removed by DCE.
+WAIT_CONSUME_IR = r"""
+module {
+  tt.func public @kernel(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+                         %arg1: i32 {tt.divisibility = 16 : i32},
+                         %arg2: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+                         %arg3: !tt.ptr<f32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %c1_i32 = arith.constant 1 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %cst = arith.constant dense<0.000000e+00> : tensor<1xf32>
+    %addptr = tt.addptr %arg0, %c1_i32 : !tt.ptr<f32>, i32
+    %tok = distributed.wait %arg2, %arg1, %c1_i32, scope = gpu semantic = acquire : !tt.ptr<i32>, i32, i32 -> i32
+    %ct = distributed.consume_token %addptr, %tok, : !tt.ptr<f32>, i32 -> !tt.ptr<f32>
+    %remote = distributed.symm_at %arg3, %arg1, : !tt.ptr<f32>
+    "distributed.notify"(%arg0, %c1_i64, %arg1) {sigOp = 1 : i32, commScope = 1 : i32} : (!tt.ptr<f32>, i64, i32) -> ()
+    %p0 = tt.splat %ct : !tt.ptr<f32> -> tensor<1x!tt.ptr<f32>>
+    tt.store %p0, %cst : tensor<1x!tt.ptr<f32>>
+    %p1 = tt.splat %remote : !tt.ptr<f32> -> tensor<1x!tt.ptr<f32>>
+    tt.store %p1, %cst : tensor<1x!tt.ptr<f32>>
+    tt.return
+  }
+}
+"""
+
+
+def test_gm_addr_args_indices_wait_consume_notify():
+    """Verify gm_addr_args_indices after wait/consume_token/symm_at/notify conversion."""
+    ctx = _make_context()
+    module = _parse(ctx, WAIT_CONSUME_IR)
+    _run_pass(module, ctx)
+    out = module.str()
+
+    indices = _extract_gm_addr_indices(out)
+    assert indices, "No hivm.custom operators found after conversion"
+    by_symbol = {sym: idx for sym, idx in indices}
+
+    # wait: operands (%arg2: ptr, %arg1: i32, %c1: i32), only %arg2 is a pointer parameter -> [0]
+    assert by_symbol["aclshmem_wait_int32"] == [0], (f"wait's gm_addr_args_indices should be [0], actual: "
+                                                     f"{by_symbol['aclshmem_wait_int32']}")
+    # consume_token: operands (%addptr: ptr non-parameter, %tok: i32), no pointer parameters -> []
+    assert by_symbol["aclshmem_consume_token_float_ptr_1d"] == [], (
+        f"consume_token's gm_addr_args_indices should be [], actual: "
+        f"{by_symbol['aclshmem_consume_token_float_ptr_1d']}")
+    # symm_at: operands (%arg3: ptr parameter, %arg1: i32), only %arg3 -> [0]
+    #   symbol is derived from symmAddr's pointee type (f32 -> "float"), i.e., aclshmem_ptr_float
+    assert by_symbol["aclshmem_ptr_float"] == [0], (f"symm_at's gm_addr_args_indices should be [0], actual: "
+                                                    f"{by_symbol['aclshmem_ptr_float']}")
+    # notify: operands (%arg0: ptr parameter, %c1_i64: i64, %arg1: i32), only %arg0 -> [0]
+    assert by_symbol["aclshmem_int64_p"] == [0], (f"notify's gm_addr_args_indices should be [0], actual: "
+                                                  f"{by_symbol['aclshmem_int64_p']}")
+
+
+# get_rank / get_num_ranks clear their operands to ValueRange() during conversion,
+# so the custom operators have no operands, and gm_addr_args_indices should be an empty array.
+# Both are Pure operators, and their results need to be consumed to avoid DCE removal; here we write them out via tt.store.
+GET_RANK_IR = r"""
+module {
+  tt.func public @kernel(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+                         %arg1: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %rank = distributed.get_rank %arg1 : i32
+    %nranks = distributed.get_num_ranks %arg1 : i32
+    %p0 = tt.splat %arg0 : !tt.ptr<i32> -> tensor<1x!tt.ptr<i32>>
+    %r0 = tt.splat %rank : i32 -> tensor<1xi32>
+    tt.store %p0, %r0 : tensor<1x!tt.ptr<i32>>
+    %n0 = tt.splat %nranks : i32 -> tensor<1xi32>
+    tt.store %p0, %n0 : tensor<1x!tt.ptr<i32>>
+    tt.return
+  }
+}
+"""
+
+
+def test_gm_addr_args_indices_get_rank_empty():
+    """get_rank/get_num_ranks have no pointer operands, gm_addr_args_indices should be empty."""
+    ctx = _make_context()
+    module = _parse(ctx, GET_RANK_IR)
+    _run_pass(module, ctx)
+    out = module.str()
+
+    indices = _extract_gm_addr_indices(out)
+    assert indices, "No hivm.custom operators found after conversion"
+    by_symbol = {sym: idx for sym, idx in indices}
+
+    # get_rank/get_num_ranks operands are cleared, no pointer parameters -> []
+    assert ("aclshmem_my_pe" in by_symbol), f"get_rank's corresponding custom operator not found: {by_symbol}"
+    assert by_symbol["aclshmem_my_pe"] == [], (f"get_rank's gm_addr_args_indices should be [], actual: "
+                                               f"{by_symbol['aclshmem_my_pe']}")
+    assert ("aclshmem_n_pes" in by_symbol), f"get_num_ranks' corresponding custom operator not found: {by_symbol}"
+    assert by_symbol["aclshmem_n_pes"] == [], (f"get_num_ranks' gm_addr_args_indices should be [], actual: "
+                                               f"{by_symbol['aclshmem_n_pes']}")
+
+
+# When consume_token's input is a tensor pointer (tensor<...x!tt.ptr<T>>),
+# its type is RankedTensorType rather than triton::PointerType, and should not be captured.
+# wait's barrierPtr is still a scalar pointer parameter %arg0, should be captured -> [0].
+# consume_token operands (%ptr_tensor: tensor pointer, %tok: i32) are both not scalar pointer parameters -> [].
+TENSOR_PTR_IR = r"""
+module {
+  tt.func public @kernel(%arg0: !tt.ptr<i32> {tt.divisibility = 16 : i32},
+                         %arg1: i32 {tt.divisibility = 16 : i32},
+                         %arg2: !tt.ptr<f32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %c1_i32 = arith.constant 1 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<1xf32>
+    %ptr_tensor = tt.splat %arg2 : !tt.ptr<f32> -> tensor<1x!tt.ptr<f32>>
+    %tok = distributed.wait %arg0, %arg1, %c1_i32, scope = gpu semantic = acquire : !tt.ptr<i32>, i32, i32 -> i32
+    %ct = distributed.consume_token %ptr_tensor, %tok, : tensor<1x!tt.ptr<f32>>, i32 -> tensor<1x!tt.ptr<f32>>
+    tt.store %ct, %cst : tensor<1x!tt.ptr<f32>>
+    tt.return
+  }
+}
+"""
+
+
+def test_gm_addr_args_indices_tensor_ptr_not_captured():
+    """Tensor pointers (tensor<...x!tt.ptr<T>>) should not be captured by gm_addr_args_indices."""
+    ctx = _make_context()
+    module = _parse(ctx, TENSOR_PTR_IR)
+    _run_pass(module, ctx)
+    out = module.str()
+
+    indices = _extract_gm_addr_indices(out)
+    assert indices, "No hivm.custom operators found after conversion"
+    # This IR only has one wait and one consume_token, extract them in order of appearance
+    wait_sym, wait_idx = indices[0]
+    consume_sym, consume_idx = indices[1]
+    assert (wait_sym == "aclshmem_wait_int32"), f"First custom should be wait, actual: {wait_sym}"
+    assert (consume_sym == "aclshmem_consume_token_float_ptr_1d"
+            ), f"Second custom should be consume_token, actual: {consume_sym}"
+    # wait: barrierPtr=%arg0(scalar pointer parameter) -> [0]
+    assert wait_idx == [0], f"wait's gm_addr_args_indices should be [0], actual: {wait_idx}"
+    # consume_token: input=%ptr_tensor(tensor pointer, not PointerType) -> []
+    assert consume_idx == [], (
+        f"consume_token's gm_addr_args_indices should be [] (tensor pointer should not be captured), "
+        f"actual: {consume_idx}")

--- a/python/triton_dist/test/ascend/test_my_pe.py
+++ b/python/triton_dist/test/ascend/test_my_pe.py
@@ -50,7 +50,7 @@ def run_test_distributed(rank, world_size):
     y_ref = torch_mype(x0, rank, 3)
     _shmemx_get_my_pe[3, 1, 1](x0)
     assert torch.equal(x0.cpu(), y_ref.cpu())
-    _ = ash.aclshmem_finialize()
+    _ = ash.aclshmem_finalize()
 
 
 @pytest.mark.dist

--- a/python/triton_dist/test/ascend/test_num_ranks.py
+++ b/python/triton_dist/test/ascend/test_num_ranks.py
@@ -50,7 +50,7 @@ def run_test_distributed(rank, world_size):
     y_ref = torch_num_ranks(x0, world_size, 3)
     _shmemx_get_num_ranks[3, 1, 1](x0)
     assert torch.equal(x0.cpu(), y_ref.cpu())
-    _ = ash.aclshmem_finialize()
+    _ = ash.aclshmem_finalize()
 
 
 @pytest.mark.dist

--- a/python/triton_dist/test/ascend/test_put_get_mem.py
+++ b/python/triton_dist/test/ascend/test_put_get_mem.py
@@ -1,0 +1,247 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+import pytest
+import torch
+import shmem as ash
+import torch.distributed as dist
+import triton.language as tl
+import triton
+from triton_dist.language.extra import libshmem_device
+
+G_ASH_SIZE = 1024 * 1024 * 1024
+TEST_ELEMS = 32
+
+
+@triton.jit
+def barrier_all_putmem_signal_kernel(sync_ptr, epoch, world_size: tl.constexpr, my_rank: tl.constexpr):
+    """Inter-node barrier using putmem_signal + signal_wait_until."""
+    if tl.program_id(axis=0) == 0:
+        tl.store(sync_ptr + my_rank, epoch)
+
+        peer = 0
+        while peer < world_size:
+            if peer != my_rank:
+                libshmem_device.putmem_signal(
+                    sync_ptr + my_rank,
+                    sync_ptr + my_rank,
+                    4,
+                    sync_ptr + my_rank,
+                    epoch,
+                    libshmem_device.ACLSHMEM_SIGNAL_SET,
+                    peer,
+                )
+            peer += 1
+
+        peer = 0
+        while peer < world_size:
+            if peer != my_rank:
+                libshmem_device.signal_wait_until(
+                    sync_ptr + peer,
+                    libshmem_device.ACLSHMEM_CMP_GE,
+                    epoch,
+                )
+            peer += 1
+
+
+def barrier_all_putmem_signal(sync_ptr, epoch, world_size: tl.constexpr, my_rank: tl.constexpr):
+    epoch += 1
+    barrier_all_putmem_signal_kernel[(1, 1, 1)](sync_ptr, epoch, world_size, my_rank)
+    return epoch
+
+
+@triton.jit
+def putmem_kernel(src, dst, nbytes: tl.constexpr, peer_rank: tl.constexpr):
+    if tl.program_id(axis=0) == 0:
+        libshmem_device.putmem(dst, src, nbytes, peer_rank)
+
+
+@triton.jit
+def getmem_kernel(src, dst, nbytes: tl.constexpr, peer_rank: tl.constexpr):
+    if tl.program_id(axis=0) == 0:
+        libshmem_device.getmem(dst, src, nbytes, peer_rank)
+
+
+@triton.jit
+def putmem_nbi_kernel(src, dst, nbytes: tl.constexpr, peer_rank: tl.constexpr):
+    if tl.program_id(axis=0) == 0:
+        libshmem_device.putmem_nbi(dst, src, nbytes, peer_rank)
+        libshmem_device.quiet()
+
+
+@triton.jit
+def getmem_nbi_kernel(src, dst, nbytes: tl.constexpr, peer: tl.constexpr):
+    if tl.program_id(axis=0) == 0:
+        libshmem_device.getmem_nbi(dst, src, nbytes, peer)
+        libshmem_device.quiet()
+
+
+@triton.jit
+def putmem_signal_kernel(
+    src,
+    dst,
+    signal_ptr,
+    nbytes: tl.constexpr,
+    signal_value,
+    peer_rank: tl.constexpr,
+    my_rank: tl.constexpr,
+):
+    if tl.program_id(axis=0) == 0:
+        libshmem_device.putmem_signal(
+            dst,
+            src,
+            nbytes,
+            signal_ptr + my_rank,
+            signal_value,
+            libshmem_device.ACLSHMEM_SIGNAL_SET,
+            peer_rank,
+        )
+
+
+@triton.jit
+def putmem_signal_nbi_kernel(
+    src,
+    dst,
+    signal_ptr,
+    nbytes: tl.constexpr,
+    signal_value,
+    peer_rank: tl.constexpr,
+    my_rank: tl.constexpr,
+):
+    if tl.program_id(axis=0) == 0:
+        libshmem_device.putmem_signal_nbi(
+            dst,
+            src,
+            nbytes,
+            signal_ptr + my_rank,
+            signal_value,
+            libshmem_device.ACLSHMEM_SIGNAL_SET,
+            peer_rank,
+        )
+        libshmem_device.quiet()
+
+
+@triton.jit
+def signal_wait_kernel(signal_ptr, signal_value, peer_rank: tl.constexpr):
+    if tl.program_id(axis=0) == 0:
+        libshmem_device.signal_wait_until(
+            signal_ptr + peer_rank,
+            libshmem_device.ACLSHMEM_CMP_GE,
+            signal_value,
+        )
+
+
+def _init_aclshmem(rank, world_size):
+    ret = ash.set_conf_store_tls(False, "")
+    if ret != 0:
+        raise ValueError("[ERROR] set_conf_store_tls failed")
+    attributes = ash.InitAttr()
+    attributes.my_rank = rank
+    attributes.n_ranks = world_size
+    attributes.local_mem_size = G_ASH_SIZE
+    attributes.ip_port = "tcp://127.0.0.1:8666"
+    attributes.option_attr.data_op_engine_type = ash.OpEngineType.MTE
+    ret = ash.aclshmem_init(attributes)
+    if ret != 0:
+        raise ValueError("[ERROR] aclshmem_init failed")
+
+
+def _build_expected(rank, world_size, elems, value_stride=1000):
+    src_rank = (rank - 1 + world_size) % world_size
+    return torch.arange(elems, dtype=torch.int32) + src_rank * value_stride
+
+
+def run_test_distributed(rank, world_size):
+    _init_aclshmem(rank, world_size)
+
+    send_peer = tl.constexpr((rank + 1) % world_size)
+    recv_peer = tl.constexpr((rank - 1 + world_size) % world_size)
+
+    src = ash.aclshmem_create_tensor([TEST_ELEMS], dtype=torch.int32, device_id=rank)
+    dst = ash.aclshmem_create_tensor([TEST_ELEMS], dtype=torch.int32, device_id=rank)
+    signal_ptr = ash.aclshmem_create_tensor([world_size], dtype=torch.int32, device_id=rank)
+
+    signal_ptr.zero_()
+    nbytes = tl.constexpr(TEST_ELEMS * src.element_size())
+    barrier_epoch = 0
+    signal_epoch = 0
+
+    src.copy_(torch.arange(TEST_ELEMS, dtype=torch.int32, device=src.device) + rank * 1000)
+    expected = _build_expected(rank, world_size, TEST_ELEMS)
+
+    def _reset_buffer():
+        dst.fill_(-1)
+
+    def _next_signal_epoch():
+        nonlocal signal_epoch
+        signal_epoch += 1
+        return signal_epoch
+
+    _reset_buffer()
+
+    putmem_kernel[1, 1, 1](src, dst, nbytes, send_peer)
+    barrier_epoch = barrier_all_putmem_signal(signal_ptr, barrier_epoch, world_size,
+                                              rank)  # dist.barrier() also works here.
+    assert torch.equal(dst.cpu(), expected), f"Rank {rank}: putmem mismatch"
+    print(f"Rank {rank}: putmem OK")
+
+    _reset_buffer()
+
+    putmem_nbi_kernel[1, 1, 1](src, dst, nbytes, send_peer)
+    dist.barrier()  # We can also use barrier_all_putmem_signal kernel here.
+    assert torch.equal(dst.cpu(), expected), f"Rank {rank}: putmem_nbi mismatch"
+    print(f"Rank {rank}: putmem_nbi OK")
+
+    _reset_buffer()
+
+    signal_value = _next_signal_epoch()
+    putmem_signal_kernel[1, 1, 1](
+        src,
+        dst,
+        signal_ptr,
+        nbytes,
+        signal_value,
+        send_peer,
+        rank,
+    )
+    signal_wait_kernel[1, 1, 1](signal_ptr, signal_value, recv_peer)
+    assert torch.equal(dst.cpu(), expected), f"Rank {rank}: putmem_signal mismatch"
+    print(f"Rank {rank}: putmem_signal OK")
+
+    _reset_buffer()
+
+    signal_value = _next_signal_epoch()
+    putmem_signal_nbi_kernel[1, 1, 1](
+        src,
+        dst,
+        signal_ptr,
+        nbytes,
+        signal_value,
+        send_peer,
+        rank,
+    )
+    signal_wait_kernel[1, 1, 1](signal_ptr, signal_value, recv_peer)
+    assert torch.equal(dst.cpu(), expected), f"Rank {rank}: putmem_signal_nbi mismatch"
+    print(f"Rank {rank}: putmem_signal_nbi OK")
+
+    _reset_buffer()
+
+    getmem_kernel[1, 1, 1](src, dst, nbytes, recv_peer)
+    assert torch.equal(dst.cpu(), expected), f"Rank {rank}: getmem mismatch"
+    print(f"Rank {rank}: getmem OK")
+
+    _reset_buffer()
+
+    getmem_nbi_kernel[1, 1, 1](src, dst, nbytes, recv_peer)
+    assert torch.equal(dst.cpu(), expected), f"Rank {rank}: getmem_nbi mismatch"
+    print(f"Rank {rank}: getmem_nbi OK")
+
+    dist.barrier()  # sync before freeing tensor to avoid race condition
+
+    ash.aclshmem_free_tensor(src)
+    ash.aclshmem_free_tensor(dst)
+    ash.aclshmem_free_tensor(signal_ptr)
+    _ = ash.aclshmem_finalize()
+
+
+@pytest.mark.dist
+def test_put_get_mem(dist_test):
+    dist_test(run_test_distributed, world_size=2)

--- a/python/triton_dist/test/ascend/test_signal_op.py
+++ b/python/triton_dist/test/ascend/test_signal_op.py
@@ -1,0 +1,160 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+import pytest
+import torch
+import shmem as ash
+import torch.distributed as dist
+import triton.language as tl
+import triton
+from triton_dist.language.extra import libshmem_device
+
+G_ASH_SIZE = 1024 * 1024 * 1024
+
+
+def _init_aclshmem(rank, world_size):
+    ret = ash.set_conf_store_tls(False, "")
+    if ret != 0:
+        raise ValueError("[ERROR] set_conf_store_tls failed")
+    attributes = ash.InitAttr()
+    attributes.my_rank = rank
+    attributes.n_ranks = world_size
+    attributes.local_mem_size = G_ASH_SIZE
+    attributes.ip_port = "tcp://127.0.0.1:8666"
+    attributes.option_attr.data_op_engine_type = ash.OpEngineType.MTE
+    ret = ash.aclshmem_init(attributes)
+    if ret != 0:
+        raise ValueError("[ERROR] aclshmem_init failed")
+
+
+@triton.jit
+def signal_set_ring_kernel(sig_ptr, my_rank: tl.constexpr, world_size: tl.constexpr):
+    """Each rank sets the next rank's signal, then waits for its own."""
+    if tl.program_id(axis=0) == 0:
+        next_pe = (my_rank + 1) % world_size
+        expected = my_rank + 1
+        signal_val = next_pe + 1
+        libshmem_device.signal_op(
+            sig_ptr,
+            signal_val,
+            libshmem_device.ACLSHMEM_SIGNAL_SET,
+            next_pe,
+        )
+        libshmem_device.signal_wait_until(
+            sig_ptr,
+            libshmem_device.ACLSHMEM_CMP_EQ,
+            expected,
+        )
+
+
+@triton.jit
+def signal_wait_until_retval_kernel(sig_ptr, ret_ptr, wait_val: tl.constexpr, my_rank: tl.constexpr,
+                                    world_size: tl.constexpr):
+    """Rank 0 waits for a known signal value; rank 1 sets it.
+    The return value of signal_wait_until (the satisfied signal value) is
+    written to ret_ptr so the host can verify it."""
+    if tl.program_id(axis=0) == 0:
+        if my_rank == 0:
+            ret = libshmem_device.signal_wait_until(
+                sig_ptr,
+                libshmem_device.ACLSHMEM_CMP_EQ,
+                wait_val,
+            )
+            tl.store(ret_ptr, ret)
+        else:
+            # Give rank 0 time to enter the wait before we signal it.
+            peer = 0
+            libshmem_device.signal_op(
+                sig_ptr,
+                wait_val,
+                libshmem_device.ACLSHMEM_SIGNAL_SET,
+                peer,
+            )
+
+
+@triton.jit
+def signal_pingpong_kernel(sig_ptr, iters: tl.constexpr, my_rank: tl.constexpr):
+    """Ping-pong signal_op / signal_wait_until between rank 0 and rank 1."""
+    if tl.program_id(axis=0) == 0:
+        peer = 1 - my_rank
+        n = 0
+        while n < iters:
+            val = 1 + n
+            if my_rank == 0:
+                libshmem_device.signal_wait_until(
+                    sig_ptr,
+                    libshmem_device.ACLSHMEM_CMP_EQ,
+                    val,
+                )
+                libshmem_device.signal_op(
+                    sig_ptr,
+                    val,
+                    libshmem_device.ACLSHMEM_SIGNAL_SET,
+                    peer,
+                )
+            else:
+                libshmem_device.signal_op(
+                    sig_ptr,
+                    val,
+                    libshmem_device.ACLSHMEM_SIGNAL_SET,
+                    peer,
+                )
+                libshmem_device.signal_wait_until(
+                    sig_ptr,
+                    libshmem_device.ACLSHMEM_CMP_EQ,
+                    val,
+                )
+            n += 1
+
+
+def run_test_distributed(rank, world_size):
+    _init_aclshmem(rank, world_size)
+
+    sig_ptr = ash.aclshmem_create_tensor([1], dtype=torch.int32, device_id=rank)
+
+    # --- signal_wait_until return value: rank 0 waits, rank 1 signals ---
+    if world_size >= 2:
+        sig_ptr.zero_()
+        ret_ptr = ash.aclshmem_create_tensor([1], dtype=torch.int32, device_id=rank)
+        ret_ptr.zero_()
+        wait_val = 42
+        dist.barrier()
+        signal_wait_until_retval_kernel[(1, 1, 1)](sig_ptr, ret_ptr, wait_val, rank, world_size)
+        dist.barrier()
+        if rank == 0:
+            got = ret_ptr.cpu().item()
+            assert got == wait_val, (f"Rank 0: signal_wait_until return value expected {wait_val}, got {got}")
+            print(f"Rank {rank}: signal_wait_until return value OK (got {got})")
+        ash.aclshmem_free_tensor(ret_ptr)
+
+    dist.barrier()
+
+    # --- signal_op + signal_wait_until with ACLSHMEM_SIGNAL_SET (ring) ---
+    sig_ptr.zero_()
+    dist.barrier()
+    signal_set_ring_kernel[(1, 1, 1)](sig_ptr, rank, world_size)
+    expected = rank + 1
+    assert sig_ptr.cpu().item() == expected, (
+        f"Rank {rank}: signal_set_ring expected {expected}, got {sig_ptr.cpu().item()}")
+    print(f"Rank {rank}: signal_set_ring OK")
+
+    # --- ping-pong between rank 0 and rank 1 ---
+    if world_size >= 2:
+        sig_ptr.zero_()
+        dist.barrier()
+        pingpong_iters = 100
+        if rank <= 1:
+            signal_pingpong_kernel[(1, 1, 1)](sig_ptr, pingpong_iters, rank)
+        dist.barrier()
+        if rank == 0:
+            assert sig_ptr.cpu().item() == pingpong_iters, (
+                f"Rank 0: signal_pingpong expected {pingpong_iters}, got {sig_ptr.cpu().item()}")
+            print(f"Rank {rank}: signal_pingpong OK")
+
+    dist.barrier()
+
+    ash.aclshmem_free_tensor(sig_ptr)
+    _ = ash.aclshmem_finalize()
+
+
+@pytest.mark.dist
+def test_signal_op(dist_test):
+    dist_test(run_test_distributed, world_size=2)

--- a/python/triton_dist/test/ascend/test_symm_at.py
+++ b/python/triton_dist/test/ascend/test_symm_at.py
@@ -72,7 +72,7 @@ def run_test_distributed(rank, world_size):
 
     # Cleanup
     ash.aclshmem_free_tensor(remote_mem)
-    _ = ash.aclshmem_finialize()
+    _ = ash.aclshmem_finalize()
 
 
 @pytest.mark.dist

--- a/python/triton_dist/test/ascend/test_wait_notify.py
+++ b/python/triton_dist/test/ascend/test_wait_notify.py
@@ -92,7 +92,7 @@ def run_test_distributed(rank, world_size):
     # Cleanup
     ash.aclshmem_free_tensor(data_mem)
     ash.aclshmem_free_tensor(signal_mem)
-    _ = ash.aclshmem_finialize()
+    _ = ash.aclshmem_finalize()
 
 
 @pytest.mark.dist

--- a/scripts/build_e2e_env.sh
+++ b/scripts/build_e2e_env.sh
@@ -111,7 +111,8 @@ fi
 # --- Install common packages ---
 echo "Installing common packages: transformers and numpy..."
 pip install transformers==4.51.3 numpy==1.26.4 termcolor
-pip install --upgrade deepspeed
+# deepspeed>=0.19.3 circular-imports with transformers==4.51.3
+pip install deepspeed==0.19.2
 
 # --- Define Hugging Face models to download ---
 MODELS=(

--- a/tutorials/ascend/01-ascend-allgather-gemm.py
+++ b/tutorials/ascend/01-ascend-allgather-gemm.py
@@ -333,7 +333,7 @@ def run_test_distributed():
             raise AssertionError(error_msg)
 
     ash.aclshmem_free_tensor(peer_mem)
-    _ = ash.aclshmem_finialize()
+    _ = ash.aclshmem_finalize()
 
 
 if __name__ == "__main__":

--- a/tutorials/ascend/02-ascend-gemm-reduce-scatter.py
+++ b/tutorials/ascend/02-ascend-gemm-reduce-scatter.py
@@ -347,7 +347,7 @@ def run_test_distributed():
             raise AssertionError(error_msg)
 
     ash.aclshmem_free_tensor(peer_mem)
-    _ = ash.aclshmem_finialize()
+    _ = ash.aclshmem_finalize()
 
 
 if __name__ == "__main__":

--- a/tutorials/ascend/03-ascend-gemm-allreduce-oneshot.py
+++ b/tutorials/ascend/03-ascend-gemm-allreduce-oneshot.py
@@ -360,7 +360,7 @@ def run_test_distributed():
             raise AssertionError(error_msg)
 
     ash.aclshmem_free_tensor(peer_mem)
-    _ = ash.aclshmem_finialize()
+    _ = ash.aclshmem_finalize()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Add Ascend RDMA support and update ACLSHMEM to `v1.5.0.rc1`.

This PR bumps the ACLSHMEM submodule, updates Ascend tests/tutorials for the corrected `aclshmem_finalize()` API, restores the shared `libshmem_device` dispatch proxy surface, and adds Ascend device wrappers for ACLSHMEM RMA, signaling, team queries, barriers, `quiet`, and `fence`.

It also updates `ModuleProxy.dispatch` so proxied Triton builtins advertise `_semantic` in their generated wrapper signatures. This is required for the Ascend path because `triton-ascend` follows Triton 3.5-style codegen, which only injects `_semantic` when it is present in the callable signature. The proxy forwards `_semantic` only to backend methods that accept it, preserving CUDA, HIP, and MACA compatibility.

## Changes
- Bump `3rdparty/shmem` to ACLSHMEM `v1.5.0.rc1`.
- Update triton-ascend submodule repository link in `.gitmodules`
- Replace deprecated `aclshmem_finialize()` usages with `aclshmem_finalize()`.
- Restore the shared `libshmem_device` dispatch proxy API by:
  - removing explicit `_semantic` parameters from dispatch stubs
  - returning to unconditional backend module imports
- Update `ModuleProxy.dispatch` to:
  - advertise `_semantic=None` in generated wrapper signatures
  - forward `_semantic` only when the selected backend method declares it
  - preserve the original dispatch stub signature
- Add Ascend ACLSHMEM wrappers for:
  - team queries: `team_my_pe`, `team_n_pes`, `team_translate_pe`
  - barriers: `barrier`, `barrier_vec`
  - RMA: `getmem`, `putmem`, `getmem_nbi`, `putmem_nbi`
  - signaling: `putmem_signal`, `putmem_signal_nbi`, `signal_op`, `signal_wait_until`
  - ordering: `quiet`, `fence`
- Expose ACLSHMEM team, compare, and signal constants through the shared SHMEM proxy API.
- Add Ascend dtype-to-kernel suffix mapping for RMA extern calls.
- Keep Triton pointer types hashable for Ascend extern signature dictionaries.
- Wire Ascend SHMEM extern handling.
- Preserve distributed-to-HIVM side effects using MLIR memory-effect information instead of a hardcoded symbol list.
- Improve Ascend distributed test setup with required environment variables and `dist` pytest marker registration.
- Add `gm_addr_args_indices` attribute to HIVM custom operators to track function parameter pointers.

## Testing
Added Ascend distributed tests for:
- barriers, vector barriers, and `barrier_all`
- world-team and sub-team barrier behavior
- `putmem` / `putmem_nbi`
- `getmem` / `getmem_nbi`
- `putmem_signal` / `putmem_signal_nbi`
- `signal_op`
- `signal_wait_until`

New test files:
- `python/triton_dist/test/ascend/test_barrier_ops.py`
- `python/triton_dist/test/ascend/test_put_get_mem.py`
- `python/triton_dist/test/ascend/test_signal_op.py`
- `python/triton_dist/test/ascend/test_gm_addr_args_indices.py`

These cover ACLSHMEM team/world barriers, vector barriers, sub-team participation, blocking and non-blocking RMA with `quiet`, signal set/wait behavior, and rank-to-rank ping-pong signaling.

## Notes
- `ModuleProxy.dispatch` carries the `_semantic` compatibility fix centrally, avoiding `_semantic` parameters in every shared `libshmem_device` dispatch stub.
- ACLSHMEM RMA currently supports the dtype subset listed in `RMA_DTYPES`, with suffixes mapped through `DTYPE_TO_KERNEL_SUFFIX`.
- Ascend SHMEM extern handling uses an empty `libshmem` path because ACLSHMEM device symbols are handled by AscendNPU-IR rather than a separate bitcode library.